### PR TITLE
Make installable

### DIFF
--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -1,5 +1,6 @@
 #!python
 from argparse import ArgumentParser
+import logging
 import sys
 
 from nchelpers import CFDataset

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup
 __version__ = (0, 1, 0)
 
 setup(
-    name='dp',
+    name='ce-dataprep',
     description='PCIC Climate Explorer Data Preparation',
     version='.'.join(str(d) for d in __version__),
     author='Rod Glover',
@@ -18,6 +18,7 @@ setup(
         pint
         PyYAML
     '''.split(),
+    packages=['dp'],
     package_data = {
         'dp': ['tests/data/*.nc']
     },
@@ -26,19 +27,19 @@ setup(
         scripts/split_merged_climos
         scripts/update_metadata
     '''.split(),
-    classifiers='''
-        Development Status :: 4 - Beta,
-        Environment :: Console,
-        Intended Audience :: Developers,
-        Intended Audience :: Science/Research,
-        License :: OSI Approved :: GNU General Public License v3 (GPLv3)
-        Operating System :: OS Independent,
-        Programming Language :: Python :: 2.7,
-        Programming Language :: Python :: 3.5,
-        Programming Language :: Python :: 3.6,
-        Topic :: Scientific/Engineering,
-        Topic :: Database,
-        Topic :: Software Development :: Libraries :: Python Modules
-    '''.split()
+    classifiers=[
+        'Development Status :: 4 - Beta',
+        'Environment :: Console',
+        'Intended Audience :: Developers',
+        'Intended Audience :: Science/Research',
+        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
+        'Operating System :: OS Independent',
+        'Programming Language :: Python :: 2.7',
+        'Programming Language :: Python :: 3.5',
+        'Programming Language :: Python :: 3.6',
+        'Topic :: Scientific/Engineering',
+        'Topic :: Database',
+        'Topic :: Software Development :: Libraries :: Python Modules'
+    ]
 
 )


### PR DESCRIPTION
Fix some mistakes made when migrating this code to here.

Changes the published name of the package from `dp` to ce-dataprep`. The actual module imported is still called `dp`.