### PR TITLE
Improve update_metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,7 +212,7 @@ You only need to know a couple of things about YAML and how we employ it to use 
     See below for details.
     * If you care about the order that attributes are processed in (and will appear in any naive
       listing of the attributes), prefix all of the second-level items with a dash (-). This causes
-      the attributes to be processed in order the order listed in the updates file.
+      the attributes to be processed in the order listed in the updates file.
 
 ##### Delete attribute
 

--- a/README.md
+++ b/README.md
@@ -210,6 +210,9 @@ You only need to know a couple of things about YAML and how we employ it to use 
     * The *value* for a first-level key is the indented block below it.
   * The second (indented) level specifies the attribute and the change to be made to it.
     See below for details.
+    * If you care about the order that attributes are processed in (and will appear in any naive
+      listing of the attributes), prefix all of the second-level items with a dash (-). This causes
+      the attributes to be processed in order the order listed in the updates file.
 
 ##### Delete attribute
 
@@ -220,6 +223,14 @@ global-or-variable-name:
     name:
 ```
 
+or (to process in order)
+
+```yaml
+global-or-variable-name:
+    - name:
+```
+
+
 ##### Set attribute value
 
 Set the value of the attribute `name` to `value`. If the attribute does not yet exist, it is created.
@@ -227,6 +238,13 @@ Set the value of the attribute `name` to `value`. If the attribute does not yet 
 ```yaml
 global-or-variable-name:
     name: value
+```
+
+or (to process in order)
+
+```yaml
+global-or-variable-name:
+    - name: value
 ```
 
 Note: This script is clever (courtesy of YAML cleverness) about the data type of the value specified. 
@@ -247,6 +265,13 @@ global-or-variable-name:
     newname: <-oldname
 ```
 
+or (to process in order)
+
+```yaml
+global-or-variable-name:
+    - newname: <-oldname
+```
+
 Note: The special sequence `<-` after the colon indicates renaming. 
 This means that you can't set an attribute with a value that begins with `<-`. Sorry.
 
@@ -260,6 +285,18 @@ global:
 
 temperature:
     units: degrees_C
+```
+
+or (to process in order)
+
+```yaml
+global:
+    - foo: 
+    - bar: 42
+    - baz: <-qux
+
+temperature:
+    - units: degrees_C
 ```
 
 This file causes a NetCDF file to be updated in the following way:

--- a/scripts/update_metadata
+++ b/scripts/update_metadata
@@ -24,6 +24,38 @@ logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)  # For testing, overridden by -l when run as a script
 
 
+def modify_attribute(target, attr, value):
+    if value == None:
+        logger.info("\tDeleting attribute '{}'".format(attr))
+        if hasattr(target, attr):
+            delattr(target, value)
+    else:
+        if isinstance(value, six.string_types) and value.startswith(rename_prefix):
+            old_name = value[len(rename_prefix):]
+            logger.info("\tRenaming attribute '{}' to '{}'".format(old_name, attr))
+            try:
+                setattr(target, attr, getattr(target, old_name))
+                delattr(target, old_name)
+            except AttributeError:
+                pass
+        else:
+            logger.info("\tSetting attribute '{}'".format(attr))
+            setattr(target, attr, value)
+
+
+def process(target, item):
+    if isinstance(item, tuple) and len(item) == 2:
+        modify_attribute(target, *item)
+    elif isinstance(item, list):
+        for element in item:
+            process(target, element)
+    elif isinstance(item, dict):
+        for element in item.items():
+            process(target, element)
+    else:
+        logger.error('Cannot process {}', item)
+
+
 def main(args):
     with open(args.updates) as ud:
         updates = yaml.safe_load(ud)
@@ -38,23 +70,7 @@ def main(args):
                 target = nc.variables[target_name]
                 logger.info("Attributes of variable '{}':".format(target_name))
 
-            for attr, value in updates[target_name].items():
-                if value == None:
-                    logger.info("\tDeleting attribute '{}'".format(attr))
-                    if hasattr(target, attr):
-                        delattr(target, value)
-                else:
-                    if isinstance(value, six.string_types) and value.startswith(rename_prefix):
-                        old_name = value[len(rename_prefix):]
-                        logger.info("\tRenaming attribute '{}' to '{}'".format(old_name, attr))
-                        try:
-                            setattr(target, attr, getattr(target, old_name))
-                            delattr(target, old_name)
-                        except AttributeError:
-                            pass
-                    else:
-                        logger.info("\tSetting attribute '{}'".format(attr))
-                        setattr(target, attr, value)
+            process(target, updates[target_name])
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Add ability to specify order of attribute processing. Attribute operations (set, rename, delete) can now be specified as lists (ordered) or as maps/dicts (unordered).

Why do we care? Because most of our tools list attributes in storage order in the file, and that order is set by the order in which the update operations are performed. Randomly (re)ordered attribute lists are hard to read.