### PR TITLE
Add expression evaluation to update_metadata

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,7 +231,7 @@ global-or-variable-name:
 ```
 
 
-##### Set attribute value
+##### Set attribute to simple value
 
 Set the value of the attribute `name` to `value`. If the attribute does not yet exist, it is created.
 
@@ -255,6 +255,49 @@ Note: This script is clever (courtesy of YAML cleverness) about the data type of
   If you need to force a numeric-looking value to be a string, enclose it in single or double quotes (e.g., `'123'`).
 
 More details on the [Wikipedia YAML page](https://en.wikipedia.org/wiki/YAML#Advanced_components).
+
+##### Set attribute to value of Python expression
+
+Set the value of the attribute `name` to the value of the Python expression `expression`, evaluated in a 
+context that includes the values of all NetCDF attributes as variables, and with a selection of 
+additional custom functions available.
+
+All standard Python functions are available -- including dangerous ones like `os.remove`, 
+so don't get too clever.
+
+For convenience, the values of all attributes of the target object are made available as local variables
+in the execution context. For example, the attribute named `product` in the global attribute set can be
+accessed in the expression as the variable `product`. It can be used just like any variable in any valid
+Python expression.
+
+The following custom functions are available for use in expressions:
+
+* `parse_ensemble_code(ensemble_code)`: Parse the argument as an ensemble code (`r<m>i<n>p<l>`) and return
+  a dict containing the values of each component, appropriately named as follows:
+    ```
+    {
+        'realization': <m>,
+        'initialization_method': <n>,
+        'physics_version': <l>,
+    }
+    ```
+
+If an exception is raised during evaluation of an expression, the target attribute is not set,
+an error message is printed, and processing of the remaining unprocessed updates continues.
+
+If the attribute does not yet exist, it is created.
+
+```yaml
+global-or-variable-name:
+    name: =expression
+```
+
+or (to process in order)
+
+```yaml
+global-or-variable-name:
+    - name: =expression
+```
 
 ##### Rename attribute
 

--- a/scripts/update_metadata
+++ b/scripts/update_metadata
@@ -7,13 +7,17 @@ See README for details of update specification file (YAML format).
 """
 
 import logging
+import re
+import sys
 
 from argparse import ArgumentParser
+
 from netCDF4 import Dataset
 import yaml
 import six
 
 rename_prefix = '<-'  # Or some other unlikely sequence of characters
+expression_prefix = '='
 
 formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
 handler = logging.StreamHandler()
@@ -24,23 +28,62 @@ logger.addHandler(handler)
 logger.setLevel(logging.DEBUG)  # For testing, overridden by -l when run as a script
 
 
-def modify_attribute(target, attr, value):
-    if value == None:
-        logger.info("\tDeleting attribute '{}'".format(attr))
-        if hasattr(target, attr):
-            delattr(target, attr)
-    else:
-        if isinstance(value, six.string_types) and value.startswith(rename_prefix):
-            old_name = value[len(rename_prefix):]
-            logger.info("\tRenaming attribute '{}' to '{}'".format(old_name, attr))
-            try:
-                setattr(target, attr, getattr(target, old_name))
-                delattr(target, old_name)
-            except AttributeError:
-                pass
-        else:
-            logger.info("\tSetting attribute '{}'".format(attr))
-            setattr(target, attr, value)
+# Custom functions that are provided for use by the ``=expression`` syntax.
+
+custom_functions = {}
+def custom_function(fun):
+    custom_functions[fun.__name__] = fun
+    return fun
+
+
+@custom_function
+def parse_ensemble_code(ensemble_code):
+    match = re.match(r'r(\d+)i(\d+)p(\d+)', ensemble_code)
+    if match:
+        return {
+            'realization': int(match.group(1)),
+            'initialization_method': int(match.group(2)),
+            'physics_version': int(match.group(3)),
+        }
+    raise ValueError("Could not parse '{}' as an ensemble code"
+                     .format(ensemble_code))
+
+
+def modify_attribute(target, name, value):
+    # Delete
+    if value is None:
+        logger.info("\tDeleting attribute '{}'".format(name))
+        if hasattr(target, name):
+            delattr(target, name)
+        return
+
+    # Rename
+    if (isinstance(value, six.string_types)
+          and value.startswith(rename_prefix)):
+        old_name = value[len(rename_prefix):]
+        logger.info("\tRenaming attribute '{}' to '{}'".format(old_name, name))
+        if hasattr(target, old_name):
+            setattr(target, name, getattr(target, old_name))
+            delattr(target, old_name)
+        return
+
+    # Expression evaluation
+    if (isinstance(value, six.string_types)
+          and value.startswith(expression_prefix)):
+        logger.info("\tSetting attribute '{}' to expression value".format(name))
+        try:
+            expression = value[len(expression_prefix):]
+            ncattrs = {name: getattr(target, name) for name in target.ncattrs()}
+            result = eval(expression, custom_functions, ncattrs)
+            setattr(target, name, result)
+        except Exception:
+            logger.error('\t\tException during evaluation of expression:',
+                         sys.exc_info()[0])
+        return
+
+    # Set
+    logger.info("\tSetting attribute '{}'".format(name))
+    setattr(target, name, value)
 
 
 def process(target, item):

--- a/tests/test_update_metadata.py
+++ b/tests/test_update_metadata.py
@@ -1,0 +1,1 @@
+# TODO: We're in a hurry. Have tested manually.


### PR DESCRIPTION
Resolves https://github.com/pacificclimate/climate-explorer-data-prep/issues/12

Provides a considerably more sophisticated facility than requested, but this was actually easier, exploiting Python `eval`.