### PR TITLE
update_metadata: Add variable renaming

### DIFF
--- a/dp/update_metadata.py
+++ b/dp/update_metadata.py
@@ -88,13 +88,12 @@ def cell_methods_for_var(var_name):
 
 # Helper functions
 
-def string_starts_with(prefix, string):
-    return (isinstance(string, six.string_types)
-            and string.startswith(prefix))
+def is_string_and_starts_with(prefix, thing):
+    return isinstance(thing, six.string_types) and thing.startswith(prefix)
 
 
-is_rename = partial(string_starts_with, rename_prefix)
-is_expression = partial(string_starts_with, expression_prefix)
+is_rename = partial(is_string_and_starts_with, rename_prefix)
+is_expression = partial(is_string_and_starts_with, expression_prefix)
 
 
 def strip_prefix(prefix, string):

--- a/tests/test_update_metadata.py
+++ b/tests/test_update_metadata.py
@@ -133,23 +133,60 @@ class TestSetAttributeFromExpression(object):
     {
         'dimensions': [('time', 10)],
         'variables': [
-            {'name': 'var', 'dimensions': ('time',)}
+            {'name': 'var1', 'dimensions': ('time',)},
+            {'name': 'var2', 'dimensions': ('time',)},
         ]
     }
 ], indirect=['fake_dataset'])
-@pytest.mark.parametrize('target_key, target_name', [
-    ('global', 'global'),
-    ('var', 'var'),
-    ("='va'+'r'", 'var'),
-    ("=dependent_varname", 'var'),
-])
-def test_process_updates(fake_dataset, target_key, target_name):
-    updates = {
-        target_key: {'yow': '=1+2'}
-    }
-    process_updates(fake_dataset, updates)
-    if target_name == 'global':
-        target = fake_dataset
-    else:
-        target = fake_dataset.variables[target_name]
-    assert target.yow == 3
+class TestProcessUpdates(object):
+
+    @pytest.mark.parametrize('target_key, target_name', [
+        ('global', 'global'),
+        ('var1', 'var1'),
+        ("='va'+'r1'", 'var1'),
+        ("=dependent_varname", 'var1'),
+    ])
+    def test_process_updates_attributes(self, fake_dataset, target_key, target_name):
+        updates = {
+            target_key: {'yow': '=1+2'}
+        }
+        process_updates(fake_dataset, updates)
+        if target_name == 'global':
+            target = fake_dataset
+        else:
+            target = fake_dataset.variables[target_name]
+        assert target.yow == 3
+
+    @pytest.mark.parametrize('updates, new_name, old_name', [
+        # Failing renames
+        ({'newvar': '<-foovar'}, 'newvar', 'foovar'),
+        ({'var1': '<-var2'}, 'var1', 'var2'),
+        ({'var1': '<-foovar'}, 'var1', 'foovar'),
+
+        # Successful renames
+        ({'newvar': '<-var1'}, 'newvar', 'var1'),
+        ({"='new'+'var'": '<-var1'}, 'newvar', 'var1'),
+        # ({'newvar': "<-='va'+'r1'"}, 'newvar', 'var1'),
+        # ({'newvar': '<-=dependent_varname'}, 'newvar', 'var1'),
+    ])
+    def test_process_updates_rename_var(
+            self, fake_dataset, updates, new_name, old_name
+    ):
+        old_exists, new_exists = (
+            name in fake_dataset.variables for name in (old_name, new_name)
+        )
+        process_updates(fake_dataset, updates)
+        if old_exists:
+            if new_exists:
+                assert old_name in fake_dataset.variables
+                assert new_name in fake_dataset.variables
+            else:
+                # The succesful renaming case
+                assert old_name not in fake_dataset.variables
+                assert new_name in fake_dataset.variables
+        else:
+            assert old_name not in fake_dataset.variables
+            if new_exists:
+                assert new_name in fake_dataset.variables
+            else:
+                assert new_name not in fake_dataset.variables


### PR DESCRIPTION
Resolves #36 

`update_metadata` is now not an entirely correct name, unless you regard the names of variables as metadata, which in fact one might reasonably do. So leave the name as it is.