### PR TITLE
Add ncWMS vector formatting script

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,4 +15,4 @@ install:
   - pip install -I pytest>=3.0.0
   - pip install -i https://pypi.pacificclimate.org/simple/ .
 script:
-  - py.test -v tests/test_units_helpers.py tests/test_update_metadata.py
+  - py.test -v tests/test_units_helpers.py tests/test_update_metadata.py tests/test_decompose_flow_vectors.py

--- a/README.md
+++ b/README.md
@@ -352,6 +352,32 @@ Global attributes:
 Attributes of variable named `temperature`:
 * set attribute `units` to (string) `degrees_C`
 
+### `decompose_flow_vectors`: create normalized unit vector fields from a VIC routing file
+
+#### Purpose:
+ncWMS can display vector fields as map rasters, if the vector data is arranged inside the netCDF file as two grids, one representing the eastward vectors at each grid location, the other representing northward vectors at each grid location. 
+
+VIC parametrization files encode flow direction using a number from 1 to 8. This script decomposes the flow direction vectors in a VIC parametrization file into northward and eastward vector arrays for ncWMS display.
+
+VIC routing directional vector values:
+```
+1 = North
+2 = Northeast
+3 = East
+4 = Southeast
+5 = South
+6 = Southwest
+7 = West
+8 = Northwest
+9 = Outlet of stream or river
+```
+
+#### Usage:
+`decompose_flow_vectors.py infile outfile variable`
+
+Writes to `outfile` a netCDF containing normalized vector arrays generated from `variable` in `infile`. Does not change `infile` or copy any other variables or axes to `outfile`.
+
+
 ## Indexing climatological output files
 
 Indexing is done using scripts in the [modelmeta](https://github.com/pacificclimate/modelmeta) package.

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -40,7 +40,7 @@ if not "lon" in variable.dimensions or not "lat" in variable.dimensions:
     source.close()
     sys.exit()
     
-if np.ma.max(variable[:]) > 9 or np.ma.max(variable[:].min < 1):
+if np.ma.max(variable[:]) > 9 or np.ma.min(variable[:]) < 1:
     print("Variable {} is not a valid flow routing".format(args.variable))
     source.close()
     sys.exit()
@@ -101,7 +101,7 @@ dest.variables[northvec][:] = north
 dest.setncatts(source.__dict__)
 
 #update history attribute, if present, to include this script
-if dest.history:
+if "history" in dest.ncattrs():
     dest.history ="{} {} {} {} {}\n".format(time.ctime(time.time()), parser.prog, args.source_file, args.dest_file, args.variable) + dest.history
 
 source.close()

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -1,0 +1,108 @@
+#!python
+'''This script takes a VIC-formatted parametrization file, including drainage flow
+   direction information and outputs a file with the selected flow vectors decomposed 
+   into normalized eastward and northward components formatted for ncWMS vector display. 
+   The output netCDF will contain lat lon axes and two vector grid variables for
+   ncWMS'''
+
+import argparse
+from netCDF4 import Dataset
+import numpy as np
+import time
+import sys
+import types
+
+parser = argparse.ArgumentParser(description='Process an indexed flow direction netCDF into a vectored netCDF suitable for ncWMS display')
+parser.add_argument('source_file', metavar='infile', help='source netCDF file')
+parser.add_argument('dest_file', metavar='outfile', help='destination netCDF file')
+parser.add_argument('variable', metavar='variable', help='netCDF variable describing flow direction')
+
+args = parser.parse_args()
+
+#check that source file is usable:
+source = Dataset(args.source_file, "r", format="NETCDF4")
+
+if not "lon" in source.dimensions or not "lat" in source.dimensions:
+    print("{} does not have latitude and longitude dimensions".format(args.source_file))
+    source.close()
+    sys.exit()
+
+if not args.variable in source.variables:
+    print("Variable {} is not found in {}".format(args.variable, args.source_file))
+    source.close()
+    sys.exit()
+
+
+variable = source.variables[args.variable]
+
+if not "lon" in variable.dimensions or not "lat" in variable.dimensions:
+    print("Variable {} is not associated with a grid".format(args.variable))
+    source.close()
+    sys.exit()
+    
+if np.ma.max(variable[:]) > 9 or np.ma.max(variable[:].min < 1):
+    print("Variable {} is not a valid flow routing".format(args.variable))
+    source.close()
+    sys.exit()
+
+#create destination file, same grid as original file
+dest = Dataset(args.dest_file, "w", format="NETCDF4")   
+
+dest.createDimension("lat", source.dimensions["lat"].size)
+dest.createVariable("lat", "f8", ("lat"))
+dest.variables["lat"].setncatts(source.variables["lat"].__dict__)
+dest.variables["lat"][:] = source.variables["lat"][:]
+
+dest.createDimension("lon", source.dimensions["lon"].size)
+dest.createVariable("lon", "f8", ("lon"))
+dest.variables["lon"].setncatts(source.variables["lon"].__dict__)
+dest.variables["lon"][:] = source.variables["lon"][:]
+
+#create the vector variables
+eastvec = "eastward_{}".format(args.variable)
+dest.createVariable(eastvec, "f8", ("lat", "lon"))
+dest.variables[eastvec].units = "1"
+dest.variables[eastvec].standard_name = eastvec #ncWMS relies on standard names
+dest.variables[eastvec].long_name = "Normalized eastward vector component of {}".format(args.variable)
+
+northvec = "northward_{}".format(args.variable)
+dest.createVariable(northvec, "f8", ("lat", "lon"))
+dest.variables[northvec].units = "1"
+dest.variables[northvec].standard_name = northvec #ncWMS relies on standard names
+dest.variables[northvec].long_name = "Normalized northward vector component of {}".format(args.variable)
+
+#populate variables with decomposed vectors.
+directions = [[0,0], #0 = filler
+              [1, 0], # 1 = N
+              [.7071, .7071], #2 = NE
+              [0, 1], #3 = E
+              [-.7071, .7071], #4 = SE
+              [-1, 0], #5 = S
+              [-.7071, -.7071], #6 = SW
+              [0, -1], #7 = W
+              [.7071, -.7071], #8 = NW
+              [0, 0]] #9 = outlet
+
+print("Generating eastward component")
+east = np.ma.copy(source.variables[args.variable][:])
+for (x, y), dir in np.ndenumerate(east):
+    if dir >= 0 and dir <= 9:
+        east[x][y] = directions[int(dir)][1]
+dest.variables[eastvec][:] = east
+
+print("Generating northward component")
+north = np.ma.copy(source.variables[args.variable][:])
+for (x, y), dir in np.ndenumerate(north):
+    if dir >= 0 and dir <= 9:
+        north[x][y] = directions[int(dir)][0]
+dest.variables[northvec][:] = north
+
+#copy global attributes to the new file.        
+dest.setncatts(source.__dict__)
+
+#update history attribute, if present, to include this script
+if dest.history:
+    dest.history ="{} {} {} {} {}\n".format(time.ctime(time.time()), parser.prog, args.source_file, args.dest_file, args.variable) + dest.history
+
+source.close()
+dest.close()

--- a/tests/test_decompose_flow_vectors.py
+++ b/tests/test_decompose_flow_vectors.py
@@ -1,0 +1,71 @@
+"""Tests for the decompose_flow_vectors script. Create a small netCDF
+   file, run the script, and check its output."""
+   
+from netCDF4 import Dataset
+import datetime
+import subprocess
+import os
+import numpy as np
+import numpy.ma as ma
+
+
+def create_routing_file(name, numlats, numlons, routes):
+    """Creates a simple netCDF file with latlon and flows.
+    Requires numlats and numlons to be divisors of 15."""
+    testfile = Dataset(name, "w", format="NETCDF4")
+    
+    lat = testfile.createDimension("lat", numlats)
+    lon = testfile.createDimension("lon", numlons)
+    
+    lats = testfile.createVariable("lat", "f8", ("lat"))
+    lons = testfile.createVariable("lon", "f8", ("lon"))
+    flows = testfile.createVariable("flow", "f8", ("lat", "lon"))
+    
+    lats[:] = range(45, 60, int(15 / numlats))
+    lons[:] = range(-125, -110, int(15 / numlons))
+    flows[:] = routes
+    
+    testfile.close()
+
+def test_decomposition():
+    timestamp = datetime.datetime.now().microsecond
+    infile = "testinput{}.nc".format(timestamp)
+    outfile = "testoutput{}.nc".format(timestamp)
+    create_routing_file(infile, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+    
+    subprocess.call(["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"])
+    
+    output = Dataset(outfile, "r", format = "NETCDF4")
+    north = output.variables["northward_flow"][:]
+    east = output.variables["eastward_flow"][:]
+    
+    assert(np.array_equal(north, np.array([[1., 0.7071, 0.], [-.7071, -1., -.7071], [0., .7071, 0.]])))
+    assert(np.array_equal(east, np.array([[0, 0.7071, 1], [.7071, 0, -.7071], [-1, -.7071, 0]])))
+    
+    output.close()
+    os.remove(infile)
+    os.remove(outfile)
+
+def test_missing_data():
+    timestamp = datetime.datetime.now().microsecond
+    infile = "testinput{}.nc".format(timestamp)
+    outfile = "testoutput{}.nc".format(timestamp)
+    
+    arr = np.array([1., 2, 3, 4, 5, 6, 7, 8, 9])
+    marr = ma.masked_array(arr, mask=[0, 0, 0, 1, 0, 0, 0, 0, 0] )
+    create_routing_file(infile, 3, 3, marr)
+    
+    subprocess.call(["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"])
+    
+    output = Dataset(outfile, "r", format="NetCDF4")
+    north = output.variables["northward_flow"][:]
+    assert(np.ma.is_masked(north[1][0]))
+    
+    east = output.variables["eastward_flow"][:]
+    assert(np.ma.is_masked(east[1][0]))
+    
+    output.close()
+    os.remove(infile)
+    os.remove(outfile)
+
+    


### PR DESCRIPTION
Adds a straightforward script that processes the routing matrix from a VIC parametrization netCDF file into a netCDF file that ncWMS2 can display as vector arrows. 

**Rationale**: I've found being able to look directly at the routing information valuable for developing and testing watershed-related calculations. We may or may not want to include this visualization in a user-oriented version of Climate Explorer, but it's been useful enough for development it seemed worth documenting and preserving the script to generate it.

![vectors](https://user-images.githubusercontent.com/4512605/35462621-92f11c86-02a1-11e8-8e8d-25e31d1f589c.png)