### PR TITLE
Generate monthly climos from monthly data

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -132,7 +132,7 @@ def create_climo_files(outdir, input_file, t_start, t_end,
         """
         ops_by_resolution = {
             'daily': ['ymonmean', 'yseasmean', 'timmean'],
-            'monthly': ['yseasmean', 'timmean'],
+            'monthly': ['ymonmean', 'yseasmean', 'timmean'],
             'yearly': ['timmean']
         }
         try:


### PR DESCRIPTION
The previous code falsely assumed that one cannot generate a monthly
average from a monthly climatology. However, this script creates
*interannual* averages, so it will generally have multiple months from
which to create an average.

Make sure that the cdo ymonmean command gets run even for monthly
data.