### PR TITLE
Fix use of nchelpers.CFDataset.dependent_varnames

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -115,7 +115,7 @@ def create_climo_files(outdir, input_file, t_start, t_end,
         'tx90pETCCDI', 'txnETCCDI', 'txxETCCDI', 'wsdiETCCDI',
     }
 
-    for variable in input_file.dependent_varnames:
+    for variable in input_file.dependent_varnames():
         if variable not in supported_vars:
             raise Exception("Unsupported variable: cant't yet process {}".format(variable))
 
@@ -167,7 +167,7 @@ def create_climo_files(outdir, input_file, t_start, t_end,
         climo_means_files = [
             fp
             for climo_means_file in climo_means_files
-            for fp in split_on_variables(climo_means_file, input_file.dependent_varnames)
+            for fp in split_on_variables(climo_means_file, input_file.dependent_varnames())
         ]
 
     # Move/copy the temporary files to their final output filepaths
@@ -272,7 +272,7 @@ def convert_pr_var_units(input_file, climo_means):
     """
     pr_attributes = {}  # will contain updates, if any, to pr variable attributes
 
-    if 'pr' in input_file.dependent_varnames:
+    if 'pr' in input_file.dependent_varnames():
         pr_variable = input_file.variables['pr']
         pr_units = Unit.from_udunits_str(pr_variable.units)
         if pr_units in [Unit('kg / m**2 / s'), Unit('mm / s')]:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil
 cdo
-nchelpers==5.3.0
+nchelpers==5.5.0
 pint
 PyYAML
 # for testing

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 python-dateutil
 cdo
-nchelpers
+nchelpers==5.3.0
 pint
 PyYAML
 # for testing

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -24,7 +24,8 @@ def main(args):
                         logger.info('{}: {}'.format(attr, getattr(input_file.metadata, attr)))
                     except Exception as e:
                         logger.info('{}: {}: {}'.format(attr, e.__class__.__name__, e))
-                for attr in 'dependent_varnames time_resolution is_multi_year_mean'.split():
+                logger.info('dependent_varnames: {}'.format(input_file.dependent_varnames()))
+                for attr in 'time_resolution is_multi_year_mean'.split():
                     logger.info('{}: {}'.format(attr, getattr(input_file, attr)))
         sys.exit(0)
 

--- a/tests/test_create_climo_files.py
+++ b/tests/test_create_climo_files.py
@@ -71,7 +71,7 @@ def test_existence(outdir, tiny_dataset, t_start, t_end, split_vars, split_inter
     """
     climo_files = create_climo_files(outdir, tiny_dataset, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
-    num_vars = len(tiny_dataset.dependent_varnames)
+    num_vars = len(tiny_dataset.dependent_varnames())
     num_files = 1
     num_intervals = 3  # TODO: determine this from the dataset
     if split_vars:
@@ -107,9 +107,9 @@ def test_filenames(outdir, tiny_dataset, t_start, t_end, split_vars, split_inter
     climo_files = create_climo_files(outdir, tiny_dataset, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
     if split_vars:
-        varnames = set(tiny_dataset.dependent_varnames)
+        varnames = set(tiny_dataset.dependent_varnames())
     else:
-        varnames = {'+'.join(sorted(tiny_dataset.dependent_varnames))}
+        varnames = {'+'.join(sorted(tiny_dataset.dependent_varnames()))}
     assert varnames == set(basename_components(fp)[0] for fp in climo_files)
     for fp in climo_files:
         frequency = basename_components(fp)[1]
@@ -184,13 +184,13 @@ def test_pr_units_conversion(outdir, tiny_dataset, t_start, t_end, split_vars, s
     """
     climo_files = create_climo_files(outdir, tiny_dataset, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
-    assert 'pr' in tiny_dataset.dependent_varnames
+    assert 'pr' in tiny_dataset.dependent_varnames()
     input_pr_var = tiny_dataset.variables['pr']
     assert Unit.from_udunits_str(input_pr_var.units) in [Unit('kg/m**2/s'), Unit('mm/s')]
     seconds_per_day = 86400
     for fp in climo_files:
         with CFDataset(fp) as cf:
-            if 'pr' in cf.dependent_varnames:
+            if 'pr' in cf.dependent_varnames():
                 output_pr_var = cf.variables['pr']
                 assert Unit.from_udunits_str(output_pr_var.units) in [Unit('kg/m**2/day'), Unit('mm/day')]
                 if hasattr(input_pr_var, 'scale_factor') or hasattr(input_pr_var, 'add_offset'):
@@ -225,12 +225,12 @@ def test_dependent_variables(outdir, tiny_dataset, t_start, t_end, split_vars, s
     dependent_varnames_in_cfs = set()
     for fp in climo_files:
         with CFDataset(fp) as cf:
-            dependent_varnames_in_cfs.update(cf.dependent_varnames)
+            dependent_varnames_in_cfs.update(cf.dependent_varnames())
             if split_vars:
                 # There should be one dependent variable from the input file
-                assert len(cf.dependent_varnames) == 1
+                assert len(cf.dependent_varnames()) == 1
     # All the input dependent variables should be covered by all the output files
-    assert dependent_varnames_in_cfs == set(tiny_dataset.dependent_varnames)
+    assert dependent_varnames_in_cfs == set(tiny_dataset.dependent_varnames())
 
 
 @mark.parametrize('tiny_dataset, t_start, t_end', [

--- a/tests/test_split_merged_climos.py
+++ b/tests/test_split_merged_climos.py
@@ -35,7 +35,7 @@ def test_existence(outdir, tiny_dataset):
 @mark.parametrize('tiny_dataset', datasets, indirect=['tiny_dataset'])
 def test_filenames(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
-    assert {basename_components(fp)[0] for fp in split_filepaths} == {'+'.join(sorted(tiny_dataset.dependent_varnames))}
+    assert {basename_components(fp)[0] for fp in split_filepaths} == {'+'.join(sorted(tiny_dataset.dependent_varnames()))}
     assert {basename_components(fp)[1] for fp in split_filepaths} == {'mClim', 'sClim', 'aClim'}
 
 
@@ -69,4 +69,4 @@ def test_dependent_variables(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
     for fp in split_filepaths:
         with CFDataset(fp) as cf:
-            assert tiny_dataset.dependent_varnames == cf.dependent_varnames
+            assert tiny_dataset.dependent_varnames() == cf.dependent_varnames()


### PR DESCRIPTION
Just after the release of [``nchelpers`` version 2.1.0](https://github.com/pacificclimate/nchelpers/releases/tag/2.1.0), the ``CFDataset.dependent_varnames`` attribute [was modified](https://github.com/pacificclimate/nchelpers/commit/0856e551e642aea909bc210a8764d759ba4d2eb4) from being a property to a method. However, this repository has since continued to use it as a property, in error.

This PR fixes the erroneous usage and also pins ``nchelpers`` version, so that the usage can't change out from under us again.
