### PR TITLE
Add prsn support

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -389,18 +389,20 @@ def convert_flux_var_units(input_file, climo_data):
     """If the file contains a 'pr' or 'prsn' variable, and if its units are per
        second, convert its units to per day.
     """
-    attributes = {}  # will contain updates, if any, to pr variable attributes
     flux_vars = [var for var in ['pr', 'prsn'] if var in input_file.dependent_varnames()]
 
     for flux_var in flux_vars:
+        attributes = {}  # will contain updates, if any, to flux variable attributes
         flux_variable = input_file.variables[flux_var]
         units = Unit.from_udunits_str(flux_variable.units)
+
         if units in [Unit('kg / m**2 / s'), Unit('mm / s')]:
             logger.info("Converting {} variable to units mm/day".format(flux_var))
             # Update units attribute
             attributes['units'] = (units * Unit('s / day')).to_udunits_str()
             # Multiply values by 86400 to convert from mm/s to mm/day
             seconds_per_day = 86400
+
             if hasattr(flux_variable, 'scale_factor') or hasattr(flux_variable, 'add_offset'):
                 # This is a packed file; need only modify packing parameters
                 try:
@@ -420,10 +422,10 @@ def convert_flux_var_units(input_file, climo_data):
                 # Replace pr in all-variables file
                 climo_data = cdo.replace(input=[climo_data, var_only])
 
-    # Update pr variable metadata as necessary to reflect changes madde
-    with CFDataset(climo_data, mode='r+') as cf:
-        for attr in attributes:
-            setattr(cf.variables[flux_var], attr, attributes[attr])
+        # Update pr variable metadata as necessary to reflect changes madde
+        with CFDataset(climo_data, mode='r+') as cf:
+            for attr in attributes:
+                setattr(cf.variables[flux_var], attr, attributes[attr])
 
     return climo_data
 

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -390,38 +390,31 @@ def convert_flux_var_units(input_file, climo_data):
        second, convert its units to per day.
     """
     attributes = {}  # will contain updates, if any, to pr variable attributes
+    flux_vars = [var for var in ['pr', 'prsn'] if var in input_file.dependent_varnames()]
 
-    vars = ['pr', 'prsn']
-    varname = ''
-    variable = None
-
-    for var in vars:
-        if var in input_file.dependent_varnames():
-            varname = var
-            variable = input_file.variables[var]
-
-    if varname and variable:
-        units = Unit.from_udunits_str(variable.units)
+    for flux_var in flux_vars:
+        flux_variable = input_file.variables[flux_var]
+        units = Unit.from_udunits_str(flux_variable.units)
         if units in [Unit('kg / m**2 / s'), Unit('mm / s')]:
-            logger.info("Converting {} variable to units mm/day".format(varname))
+            logger.info("Converting {} variable to units mm/day".format(flux_var))
             # Update units attribute
             attributes['units'] = (units * Unit('s / day')).to_udunits_str()
             # Multiply values by 86400 to convert from mm/s to mm/day
             seconds_per_day = 86400
-            if hasattr(variable, 'scale_factor') or hasattr(variable, 'add_offset'):
+            if hasattr(flux_variable, 'scale_factor') or hasattr(flux_variable, 'add_offset'):
                 # This is a packed file; need only modify packing parameters
                 try:
-                    attributes['scale_factor'] = seconds_per_day * variable.scale_factor
+                    attributes['scale_factor'] = seconds_per_day * flux_variable.scale_factor
                 except AttributeError:
                     attributes['scale_factor'] = seconds_per_day * 1.0  # default value 1.0 for missing scale factor
                 try:
-                    attributes['add_offset'] = seconds_per_day * variable.add_offset
+                    attributes['add_offset'] = seconds_per_day * flux_variable.add_offset
                 except AttributeError:
                     attributes['add_offset'] = 0.0  # default value 0.0 for missing offset
             else:
                 # This is not a packed file; modify the values proper
                 # Extract variable
-                var_only = cdo.select('name={}'.format(varname), input=climo_data)
+                var_only = cdo.select('name={}'.format(flux_var), input=climo_data)
                 # Multiply values by 86400 to convert from mm/s to mm/day
                 var_only = cdo.mulc(str(seconds_per_day), input=var_only)
                 # Replace pr in all-variables file
@@ -430,7 +423,7 @@ def convert_flux_var_units(input_file, climo_data):
     # Update pr variable metadata as necessary to reflect changes madde
     with CFDataset(climo_data, mode='r+') as cf:
         for attr in attributes:
-            setattr(cf.variables[varname], attr, attributes[attr])
+            setattr(cf.variables[flux_var], attr, attributes[attr])
 
     return climo_data
 

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -171,8 +171,10 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
         'fdd': 'count',
         'gdd': 'count',
         'hdd': 'count',
-        }
-    
+        # Plan2Adapt Variables
+        'prsn': 'point'
+    }
+
     try:
         var_types = {variable_types[variable] for variable in input_file.dependent_varnames()}
     except KeyError as e:
@@ -181,7 +183,7 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
     if not len(var_types) == 1:
         raise Exception("Only one type of variable allowed per file")
     var_type = list(var_types)[0]
-    
+
     # Select the temporal subset defined by t_start, t_end
     logger.info('Selecting temporal subset')
     date_range = '{},{}'.format(d2s(t_start), d2s(t_end))

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -251,7 +251,7 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
         climo_files = [convert_longitude_range(climo_file) for climo_file in climo_files]
 
     # Convert units on any pr variable in each file
-    climo_files = [convert_pr_var_units(input_file, climo_file) for climo_file in climo_files]
+    climo_files = [convert_flux_var_units(input_file, climo_file) for climo_file in climo_files]
 
     # Update metadata in climo files
     logger.debug('Updating climo metadata')
@@ -385,9 +385,9 @@ def convert_longitude_range(climo_data):
     return climo_data
 
 
-def convert_pr_var_units(input_file, climo_data):
-    """If the file contains a 'pr' variable, and if its units are per second, convert its units to per day.
-
+def convert_flux_var_units(input_file, climo_data):
+    """If the file contains a 'pr' or 'prsn' variable, and if its units are per
+       second, convert its units to per day.
     """
     attributes = {}  # will contain updates, if any, to pr variable attributes
 

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -387,40 +387,49 @@ def convert_pr_var_units(input_file, climo_data):
     """If the file contains a 'pr' variable, and if its units are per second, convert its units to per day.
 
     """
-    pr_attributes = {}  # will contain updates, if any, to pr variable attributes
+    attributes = {}  # will contain updates, if any, to pr variable attributes
 
-    if 'pr' in input_file.dependent_varnames():
-        pr_variable = input_file.variables['pr']
-        pr_units = Unit.from_udunits_str(pr_variable.units)
-        if pr_units in [Unit('kg / m**2 / s'), Unit('mm / s')]:
-            logger.info("Converting 'pr' variable to units mm/day")
+    vars = ['pr', 'prsn']
+    varname = ''
+    variable = None
+
+    for var in vars:
+        if var in input_file.dependent_varnames():
+            varname = var
+            variable = input_file.variables[var]
+
+
+    if varname and variable:
+        units = Unit.from_udunits_str(variable.units)
+        if units in [Unit('kg / m**2 / s'), Unit('mm / s')]:
+            logger.info("Converting {} variable to units mm/day".format(varname))
             # Update units attribute
-            pr_attributes['units'] = (pr_units * Unit('s / day')).to_udunits_str()
+            attributes['units'] = (units * Unit('s / day')).to_udunits_str()
             # Multiply values by 86400 to convert from mm/s to mm/day
             seconds_per_day = 86400
-            if hasattr(pr_variable, 'scale_factor') or hasattr(pr_variable, 'add_offset'):
+            if hasattr(variable, 'scale_factor') or hasattr(variable, 'add_offset'):
                 # This is a packed file; need only modify packing parameters
                 try:
-                    pr_attributes['scale_factor'] = seconds_per_day * pr_variable.scale_factor
+                    attributes['scale_factor'] = seconds_per_day * variable.scale_factor
                 except AttributeError:
-                    pr_attributes['scale_factor'] = seconds_per_day * 1.0  # default value 1.0 for missing scale factor
+                    attributes['scale_factor'] = seconds_per_day * 1.0  # default value 1.0 for missing scale factor
                 try:
-                    pr_attributes['add_offset'] = seconds_per_day * pr_variable.add_offset
+                    attributes['add_offset'] = seconds_per_day * variable.add_offset
                 except AttributeError:
-                    pr_attributes['add_offset'] = 0.0  # default value 0.0 for missing offset
+                    attributes['add_offset'] = 0.0  # default value 0.0 for missing offset
             else:
                 # This is not a packed file; modify the values proper
                 # Extract variable
-                pr_only = cdo.select('name=pr', input=climo_data)
+                var_only = cdo.select('name={}'.format(varname), input=climo_data)
                 # Multiply values by 86400 to convert from mm/s to mm/day
-                pr_only = cdo.mulc(str(seconds_per_day), input=pr_only)
+                var_only = cdo.mulc(str(seconds_per_day), input=var_only)
                 # Replace pr in all-variables file
-                climo_data = cdo.replace(input=[climo_data, pr_only])
+                climo_data = cdo.replace(input=[climo_data, var_only])
 
     # Update pr variable metadata as necessary to reflect changes madde
     with CFDataset(climo_data, mode='r+') as cf:
-        for attr in pr_attributes:
-            setattr(cf.variables['pr'], attr, pr_attributes[attr])
+        for attr in attributes:
+            setattr(cf.variables[varname], attr, attributes[attr])
 
     return climo_data
 

--- a/tests/test_create_climo_files.py
+++ b/tests/test_create_climo_files.py
@@ -63,7 +63,8 @@ def basename_components(filepath):
     ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
     ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
     ('gdd_seasonal', 'mean', t_start(1971), t_end(2000)),  # test seasonal-only
-    ('tr_annual', 'mean', t_start(1961), t_end(1990))  # test annual-only
+    ('tr_annual', 'mean', t_start(1961), t_end(1990)),  # test annual-only
+    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
 ], indirect=['tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
@@ -97,6 +98,7 @@ def test_existence(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
     ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
     ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
     ('gdd_seasonal', 'mean', t_start(1961), t_end(1990)),
+    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
 ], indirect=['tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
@@ -136,7 +138,8 @@ def test_filenames(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
     ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
     ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
     ('gdd_seasonal', 'mean', t_start(1981), t_end(2010)),
-    ('tr_annual', 'std', t_start(1960), t_end(1970))
+    ('tr_annual', 'std', t_start(1960), t_end(1970)),
+    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
 ], indirect=['tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
@@ -227,9 +230,10 @@ def test_duration_variable_resolutions(outdir, tiny_dataset, operation, t_start,
             assert tiny_dataset.time_resolution == output.time_resolution
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('downscaled_pr', 'mean', t_start(1965), t_end(1970)),
-    ('downscaled_pr_packed', 'std', t_start(1965), t_end(1970)),
+@mark.parametrize('tiny_dataset, operation, t_start, t_end, var', [
+    ('downscaled_pr', 'mean', t_start(1965), t_end(1970), 'pr'),
+    ('downscaled_pr_packed', 'std', t_start(1965), t_end(1970), 'pr'),
+    ('daily_prsn', 'mean', t_start(1950), t_end(2100), 'prsn'),
 ], indirect=['tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
@@ -239,21 +243,22 @@ def test_duration_variable_resolutions(outdir, tiny_dataset, operation, t_start,
     False,
     True,
 ])
-def test_pr_units_conversion(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_pr_units_conversion(outdir, tiny_dataset, operation, t_start, t_end, var, split_vars, split_intervals):
     """Test that units conversion for 'pr' variable is performed properly, for both packed and unpacked files.
     Test for unpacked file is pretty elementary: check pr units.
     Test for packed checks that packing params are modified correctly.
     """
     climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
-    assert 'pr' in tiny_dataset.dependent_varnames()
-    input_pr_var = tiny_dataset.variables['pr']
+
+    assert var in tiny_dataset.dependent_varnames()
+    input_pr_var = tiny_dataset.variables[var]
     assert Unit.from_udunits_str(input_pr_var.units) in [Unit('kg/m**2/s'), Unit('mm/s')]
     seconds_per_day = 86400
     for fp in climo_files:
         with CFDataset(fp) as cf:
-            if 'pr' in cf.dependent_varnames():
-                output_pr_var = cf.variables['pr']
+            if var in cf.dependent_varnames():
+                output_pr_var = cf.variables[var]
                 assert Unit.from_udunits_str(output_pr_var.units) in [Unit('kg/m**2/day'), Unit('mm/day')]
                 if hasattr(input_pr_var, 'scale_factor') or hasattr(input_pr_var, 'add_offset'):
                     try:


### PR DESCRIPTION
Resolves #65 by adding `prsn` into supported variables.  Furthermore, extended `convert_pr_var_units` to `convert_flux_var_units` to handle `prsn`.  New test file added with snowfall data and some tests were updated.