### PR TITLE
Adds climatology period option to generate_climos

### DIFF
--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -3,7 +3,7 @@ from argparse import ArgumentParser
 import logging
 import sys
 
-from nchelpers import CFDataset
+from nchelpers import CFDataset, standard_climo_periods
 from dp.argparse_helpers import strtobool, log_level_choices
 from dp.generate_climos import logger, create_climo_files
 
@@ -18,7 +18,8 @@ def main(args):
             except Exception as e:
                 logger.info('{}: {}'.format(e.__class__.__name__, e))
             else:
-                logger.info('climo_periods: {}'.format(input_file.climo_periods.keys()))
+                periods = input_file.climo_periods.keys() & args.climo
+                logger.info('climo_periods: {}'.format(periods))
                 for attr in 'project institution model emissions run'.split():
                     try:
                         logger.info('{}: {}'.format(attr, getattr(input_file.metadata, attr)))
@@ -37,15 +38,19 @@ def main(args):
         except Exception as e:
             logger.info('{}: {}'.format(e.__class__.__name__, e))
         else:
-            for _, t_range in input_file.climo_periods.items():
+            for period in input_file.climo_periods.keys() & args.climo:
+                t_range = input_file.climo_periods[period]
                 create_climo_files(args.outdir, input_file, args.operation, *t_range,
                                    convert_longitudes=args.convert_longitudes, split_vars=args.split_vars)
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Create climatologies from CMIP5 data')
     parser.add_argument('filepaths', nargs='*', help='Files to process')
-    # parser.add_argument('-c', '--climo', nargs= '+',  help='Climatological periods to generate.
-    # IN PROGRESS. Defaults to all available in the input file. Ex: -c 6190 7100 8100 2020 2050 2080')
+    parser.add_argument('-c', '--climo', default=[], action='append',
+                        choices=standard_climo_periods().keys(),
+                        help='Climatological periods to generate. '
+                        'Defaults to all available in the input file. '
+                        'Ex: -c 6190 -c 7100 -c 8100 -c 2020 -c 2050 -c 2080')
     parser.add_argument('-l', '--loglevel', help='Logging level',
                         choices=log_level_choices, default='INFO')
     parser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true')
@@ -60,5 +65,7 @@ if __name__ == '__main__':
                         choices=['mean', 'std'])
     parser.set_defaults(dry_run=False, convert_longitudes=True, split_vars=True, split_intervals=True)
     args = parser.parse_args()
+    if not args.climo:
+        args.climo = standard_climo_periods().keys()
     logger.setLevel(getattr(logging, args.loglevel))
     main(args)


### PR DESCRIPTION
Resolves #74 The `-c --climo` option can be used multiple times, once for each climatological period that you wish to compute. Defaults to all. Options are included in the help and are gathered from the "standard" climatology names in ``nchelpers``.

This is pretty straightforward, but does anyone have time to briefly look over this.