### PR TITLE
Adds --resolution argument to generate_climos

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -2,6 +2,7 @@ import os
 import os.path
 import logging
 import shutil
+import warnings
 
 from datetime import datetime
 import dateutil.parser
@@ -227,6 +228,16 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
             operations.update(aggregate_climo_ops[time_resolution])
         # Filter the operations by resolution to create
         operations = [operations[rez] for rez in output_resolutions if rez in operations]
+
+        # It's possible that the set of user selected output
+        # resolutions is disjoint with the set of available output
+        # resoultions
+        if not operations:
+            warnings.warn("None of the selected output resolutions %s are "
+                          "computable from a file with %s temporal resolution"
+                          .format(' ,'.join(output_resolutions), time_resolution))
+            return []
+
         try:
             return [getattr(cdo, op)(input=data) for op in operations]
         except:

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -41,7 +41,8 @@ def main(args):
             for period in input_file.climo_periods.keys() & args.climo:
                 t_range = input_file.climo_periods[period]
                 create_climo_files(args.outdir, input_file, args.operation, *t_range,
-                                   convert_longitudes=args.convert_longitudes, split_vars=args.split_vars)
+                                   convert_longitudes=args.convert_longitudes, split_vars=args.split_vars,
+                                   output_resolutions=args.resolutions)
 
 if __name__ == '__main__':
     parser = ArgumentParser(description='Create climatologies from CMIP5 data')
@@ -51,6 +52,11 @@ if __name__ == '__main__':
                         help='Climatological periods to generate. '
                         'Defaults to all available in the input file. '
                         'Ex: -c 6190 -c 7100 -c 8100 -c 2020 -c 2050 -c 2080')
+    parser.add_argument('-r', '--resolutions', default=[], action='append',
+                        choices=['yearly', 'seasonal', 'monthly'],
+                        help='Temporal resolutions of multiyear means to generate. '
+                        'Defaults to ["yearly", "seasonal", "monthly"] '
+                        'Ex: -r yearly -r seasonal')
     parser.add_argument('-l', '--loglevel', help='Logging level',
                         choices=log_level_choices, default='INFO')
     parser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true')
@@ -67,5 +73,7 @@ if __name__ == '__main__':
     args = parser.parse_args()
     if not args.climo:
         args.climo = standard_climo_periods().keys()
+    if not args.resolutions:
+        args.resolutions = ['yearly', 'seasonal', 'monthly']
     logger.setLevel(getattr(logging, args.loglevel))
     main(args)

--- a/tests/test_create_climo_files.py
+++ b/tests/test_create_climo_files.py
@@ -20,7 +20,7 @@ from datetime import datetime
 
 from netCDF4 import date2num
 from dateutil.relativedelta import relativedelta
-from pytest import mark
+from pytest import mark, warns
 
 from nchelpers import CFDataset
 
@@ -449,3 +449,22 @@ def test_resolution_filter(outdir, datasets, resolutions, split_intervals):
         assert len(climo_files) == len(resolutions)
     else:
         assert len(climo_files) == min(1, len(resolutions))
+
+
+@mark.parametrize(('tiny_dataset'), [
+    'tr_annual'
+], indirect=['tiny_dataset'])
+def test_resolution_warning(outdir, tiny_dataset):
+    '''If we try to compute a monthly climo from an annual file
+       there should be zero output files and a warning issued
+    '''
+    with warns(Warning) as record:
+        climo_files = create_climo_files(
+            outdir, tiny_dataset, 'mean', t_start(1965),
+            t_end(1971), split_vars=True, split_intervals=True,
+            convert_longitudes=True, output_resolutions={'monthly'}
+        )
+
+    assert climo_files == []
+    assert len(record) == 1
+    assert "None of the selected output resolutions" in str(record[0].message)

--- a/tests/test_create_climo_files.py
+++ b/tests/test_create_climo_files.py
@@ -423,3 +423,29 @@ def test_convert_longitudes(outdir, tiny_dataset, operation, t_start, t_end, spl
                 else:
                     assert all(-180 <= lon < 360 for _, lon in enumerate(output_lon_var))
                     assert all(output_lon_var[i] == input_lon for i, input_lon in enumerate(input_lon_var))
+
+
+@mark.parametrize(('resolutions'), [
+    {'yearly'},
+    {'yearly', 'seasonal'},
+    {'yearly', 'seasonal', 'monthly'},
+    {'monthly', 'daily'}, # Daily does not exist
+    set()
+])
+@mark.parametrize(('split_intervals'), [
+    True,
+    False
+])
+def test_resolution_filter(outdir, datasets, resolutions, split_intervals):
+    tiny_dataset = datasets['tasmax']
+    climo_files = create_climo_files(
+        outdir, tiny_dataset, 'mean', t_start(1965), t_end(1970),
+        split_vars=False, split_intervals=split_intervals,
+        convert_longitudes=False, output_resolutions=resolutions
+    )
+    # Only these resolutions are supported as aggregation targets
+    if split_intervals:
+        resolutions = resolutions.intersection({'yearly', 'seasonal', 'monthly'})
+        assert len(climo_files) == len(resolutions)
+    else:
+        assert len(climo_files) == min(1, len(resolutions))


### PR DESCRIPTION
This PR adds the ability to only generate a subset of the available time resolutions (the default maintains the functionality of generating all that are available). Anyone have a minute or two to take a look at this?