### PR TITLE
Add the ability to pipe YAML to update_metadata

### DIFF
--- a/scripts/update_metadata
+++ b/scripts/update_metadata
@@ -5,6 +5,7 @@ WARNING: THIS SCRIPT MODIFIES THE ORIGINAL FILE.
 
 See README for details of update specification file (YAML format).
 """
+import sys
 from argparse import ArgumentParser
 import logging
 
@@ -27,5 +28,7 @@ if __name__ == '__main__':
         help='NetCDF file to update'
     )
     args = parser.parse_args()
+    if args.updates == '-':
+        args.updates = sys.stdin
     logger.setLevel(getattr(logging, args.loglevel))
     main(args)


### PR DESCRIPTION
In the Unix world, it's often useful to pipe input to a process on
STDIN especially when one is scripting things. This change adds the
ability for the update_metadata script to take input on STDIN if the
"-u -" option is used.