### PR TITLE
Add Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -1,0 +1,23 @@
+@Library('pcic-pipeline-library@1.0.1')_
+
+
+node {
+    stage('Code Collection') {
+        collectCode()
+    }
+
+    stage('Python Test Suite') {
+        def pytestArgs = '-v tests/test_units_helpers.py tests/test_update_metadata.py tests/test_decompose_flow_vectors.py'
+        runPythonTestSuite('pcic/geospatial-python', ['requirements.txt'], pytestArgs)
+    }
+
+    if (isPypiPublishable()) {
+        stage('Push to PYPI') {
+            publishPythonPackage('pcic/geospatial-python', 'PCIC_PYPI_CREDS')
+        }
+    }
+
+    stage('Clean Workspace') {
+        cleanWs()
+    }
+}


### PR DESCRIPTION
This PR introduces support for Jenkins.  The pipeline runs some tests and will automatically release packages to pypi. This resolves #93 for the future. However, we will still need to release a package manually if we do not intend to tag immediately after this merge.