### PR TITLE
Update Jenkinsfile

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -7,13 +7,22 @@ node {
     }
 
     stage('Python Test Suite') {
-        def pytestArgs = '-v tests/test_units_helpers.py tests/test_update_metadata.py tests/test_decompose_flow_vectors.py'
-        runPythonTestSuite('pcic/geospatial-python', ['requirements.txt'], pytestArgs)
+        def options = [aptPackages: ['cdo']]
+        def pytestArgs = '-v --ignore=tests/test_decompose_flow_vectors.py'
+        parallel "Python 3.6": {
+            runPythonTestSuite('pcic/crmprtd-test-env:python-3.6',
+                               ['requirements.txt'], pytestArgs, options)
+        },
+        "Python 3.7": {
+            runPythonTestSuite('pcic/crmprtd-test-env:python-3.7',
+                               ['requirements.txt'], pytestArgs, options)
+        }
     }
 
     if (isPypiPublishable()) {
         stage('Push to PYPI') {
-            publishPythonPackage('pcic/geospatial-python', 'PCIC_PYPI_CREDS')
+            publishPythonPackage('pcic/crmprtd-test-env:python-3.6',
+                                 'PCIC_PYPI_CREDS')
         }
     }
 


### PR DESCRIPTION
Several updates have been made:
- Now installs `cdo` and runs all tests*
- Base container has been changed to allow for automated package building and releasing
- Runs tests in python `3.6` and `3.7`

\* There are two tests that were giving jenkins issues, these have been skipped in the suite and an [issue](https://github.com/pacificclimate/climate-explorer-data-prep/issues/96) was created.

Resolves #95.
