### PR TITLE
Issue 82

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -691,8 +691,10 @@ def update_metadata_and_time_var(
             history_li = history.split("\n")
             for idx, h in enumerate(history_li):
                 if compare_times(t_start_generate_climos, h[:24]):
-                    history_li.insert(idx, start)
                     break
+                if idx == len(history_li)-1:
+                    idx += 1
+            history_li.insert(idx, start)
 
             history_str = ""
             for h in history_li:

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -7,6 +7,7 @@ import warnings
 from datetime import datetime
 import dateutil.parser
 import numpy as np
+import re
 
 from cdo import Cdo
 from netCDF4 import date2num
@@ -21,7 +22,9 @@ from dp.units_helpers import Unit
 
 
 # Set up logging
-formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
+formatter = logging.Formatter(
+    "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
+)
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
 
@@ -33,9 +36,18 @@ logger.setLevel(logging.DEBUG)  # For testing, overridden by -l when run as a sc
 cdo = Cdo()
 
 
-def create_climo_files(outdir, input_file, operation, t_start, t_end,
-                       convert_longitudes=True, split_vars=True, split_intervals=True,
-                       output_resolutions={'yearly', 'seasonal', 'monthly'}):
+def create_climo_files(
+    outdir,
+    filepath,
+    input_file,
+    operation,
+    t_start,
+    t_end,
+    convert_longitudes=True,
+    split_vars=True,
+    split_intervals=True,
+    output_resolutions={"yearly", "seasonal", "monthly"},
+):
     """Generate climatological files from an input file and a selected time range.
 
     Parameters:
@@ -89,10 +101,10 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
     output file name will be misleading.
 
     """
-    logger.info('Generating climo period %s to %s', d2s(t_start), d2s(t_end))
+    logger.info("Generating climo period %s to %s", d2s(t_start), d2s(t_end))
 
     if input_file.is_multi_year:
-        raise Exception('This file already contains climatologies')
+        raise Exception("This file already contains climatologies")
 
     validate_operation(operation)
 
@@ -130,65 +142,76 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
 
     variable_types = {
         # Standard climate variables
-        'tasmin': 'point',
-        'tasmax': 'point',
-        'pr': 'point',
+        "tasmin": "point",
+        "tasmax": "point",
+        "pr": "point",
         # Hydrological modelling variables
-        'BASEFLOW': 'point',
-        'EVAP': 'point',
-        'GLAC_AREA_BAND': 'point',
-        'GLAC_MBAL_BAND': 'point',
-        'GLAC_OUTFLOW': 'point',
-        'PET_NATVEG': 'point',
-        'PREC': 'point',
-        'RAINF': 'point',
-        'RUNOFF': 'point',
-        'SNOW_MELT': 'point',
-        'SOIL_MOIST_TOT': 'point',
-        'SWE': 'point',
-        'SWE_BAND': 'point',
-        'TRANSP_VEG': 'point',
+        "BASEFLOW": "point",
+        "EVAP": "point",
+        "GLAC_AREA_BAND": "point",
+        "GLAC_MBAL_BAND": "point",
+        "GLAC_OUTFLOW": "point",
+        "PET_NATVEG": "point",
+        "PREC": "point",
+        "RAINF": "point",
+        "RUNOFF": "point",
+        "SNOW_MELT": "point",
+        "SOIL_MOIST_TOT": "point",
+        "SWE": "point",
+        "SWE_BAND": "point",
+        "TRANSP_VEG": "point",
         # Hydrological outputs
-        'streamflow': 'point',
+        "streamflow": "point",
         # Climdex variables
-        'cddETCCDI': 'duration',
-        'csdiETCCDI': 'duration',
-        'cwdETCCDI': 'duration',
-        'dtrETCCDI': 'point',
-        'fdETCCDI': 'count',
-        'gslETCCDI': 'duration',
-        'idETCCDI': 'count',
-        'prcptotETCCDI': 'count',
-        'r10mmETCCDI': 'count',
-        'r1mmETCCDI': 'count',
-        'r20mmETCCDI': 'count',
-        'r95pETCCDI': 'count',
-        'r99pETCCDI': 'count',
-        'rx1dayETCCDI': 'maximum',
-        'rx5dayETCCDI': 'maximum',
-        'sdiiETCCDI': 'point',
-        'suETCCDI': 'count',
-        'tn10pETCCDI': 'point',
-        'tn90pETCCDI': 'point',
-        'tnnETCCDI': 'minimum',
-        'tnxETCCDI': 'maximum',
-        'trETCCDI': 'count',
-        'tx10pETCCDI': 'point',
-        'tx90pETCCDI': 'point',
-        'txnETCCDI': 'minimum',
-        'txxETCCDI': 'maximum',
-        'wsdiETCCDI': 'duration',
+        "cddETCCDI": "duration",
+        "csdiETCCDI": "duration",
+        "cwdETCCDI": "duration",
+        "dtrETCCDI": "point",
+        "fdETCCDI": "count",
+        "gslETCCDI": "duration",
+        "idETCCDI": "count",
+        "prcptotETCCDI": "count",
+        "r10mmETCCDI": "count",
+        "r1mmETCCDI": "count",
+        "r20mmETCCDI": "count",
+        "r95pETCCDI": "count",
+        "r99pETCCDI": "count",
+        "rx1dayETCCDI": "maximum",
+        "rx5dayETCCDI": "maximum",
+        "sdiiETCCDI": "point",
+        "suETCCDI": "count",
+        "tn10pETCCDI": "point",
+        "tn90pETCCDI": "point",
+        "tnnETCCDI": "minimum",
+        "tnxETCCDI": "maximum",
+        "trETCCDI": "count",
+        "tx10pETCCDI": "point",
+        "tx90pETCCDI": "point",
+        "txnETCCDI": "minimum",
+        "txxETCCDI": "maximum",
+        "wsdiETCCDI": "duration",
         # Degree Day Variables
-        'cdd': 'count',
-        'fdd': 'count',
-        'gdd': 'count',
-        'hdd': 'count',
+        "cdd": "count",
+        "fdd": "count",
+        "gdd": "count",
+        "hdd": "count",
         # Plan2Adapt Variables
-        'prsn': 'point'
+        "prsn": "point",
     }
 
+    def generate_curr_time():
+        """This function returnscurrent time in the format of
+        cdo's history attribute.
+        """
+        return datetime.now().strftime("%a %B %d %H:%M:%S %Y")
+
+    # Record the starting time of generate_climos
+    t_start_generate_climos = generate_curr_time()
+
     try:
-        var_types = {variable_types[variable] for variable in input_file.dependent_varnames()}
+        var_types = {
+            variable_types[variable] for variable in input_file.dependent_varnames()
+        }
     except KeyError as e:
         raise Exception("Unsupported variable: can't yet process {}".format(e.args[0]))
 
@@ -197,13 +220,18 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
     var_type = list(var_types)[0]
 
     # Select the temporal subset defined by t_start, t_end
-    logger.info('Selecting temporal subset')
-    date_range = '{},{}'.format(d2s(t_start), d2s(t_end))
+    logger.info("Selecting temporal subset")
+    date_range = "{},{}".format(d2s(t_start), d2s(t_end))
     temporal_subset = cdo.seldate(date_range, input=input_file.filepath())
 
     # Form climatological means/standard deviations over dependent variables
-    def climo_outputs(time_resolution, operation, data, aggregate=True,
-            output_resolutions={'monthly', 'seasonal', 'yearly'}):
+    def climo_outputs(
+        time_resolution,
+        operation,
+        data,
+        aggregate=True,
+        output_resolutions={"monthly", "seasonal", "yearly"},
+    ):
         """Return a list of cdo operators that generate the desired climo outputs.
         Result depends on the time resolution of input file data. If
         aggregate is false, only operations that generate climatologies at
@@ -211,53 +239,66 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
         data will be aggregated daily -> monthly -> seasonal -> yearly.
         """
         if time_resolution == "daily" and not aggregate:
-            raise Exception("Cannot generate non-aggregated climatologies from a daily dataset")
+            raise Exception(
+                "Cannot generate non-aggregated climatologies from a daily dataset"
+            )
 
         climo_ops = {
-            'daily': {},
-            'monthly': {'monthly': 'ymon' + operation},
-            'seasonal': {'seasonal': 'yseas' + operation},
-            'yearly': {'yearly': 'tim' + operation}
-            }
+            "daily": {},
+            "monthly": {"monthly": "ymon" + operation},
+            "seasonal": {"seasonal": "yseas" + operation},
+            "yearly": {"yearly": "tim" + operation},
+        }
         aggregate_climo_ops = {
-            'daily': {
-                'monthly': 'ymon' + operation,
-                'seasonal': 'yseas' + operation,
-                'yearly': 'tim' + operation
+            "daily": {
+                "monthly": "ymon" + operation,
+                "seasonal": "yseas" + operation,
+                "yearly": "tim" + operation,
             },
-            'monthly': {
-                'seasonal': 'yseas' + operation,
-                'yearly': 'tim' + operation
-            },
-            'seasonal': {'yearly': 'tim' + operation},
-            'yearly': {}
-            }
+            "monthly": {"seasonal": "yseas" + operation, "yearly": "tim" + operation},
+            "seasonal": {"yearly": "tim" + operation},
+            "yearly": {},
+        }
         operations = climo_ops[time_resolution]
         if aggregate:
             operations.update(aggregate_climo_ops[time_resolution])
         # Filter the operations by resolution to create
-        operations = [operations[rez] for rez in output_resolutions if rez in operations]
+        operations = [
+            operations[rez] for rez in output_resolutions if rez in operations
+        ]
 
         # It's possible that the set of user selected output
         # resolutions is disjoint with the set of available output
         # resoultions
         if not operations:
-            warnings.warn("None of the selected output resolutions %s are "
-                          "computable from a file with %s temporal resolution"
-                          .format(' ,'.join(output_resolutions), time_resolution))
+            warnings.warn(
+                "None of the selected output resolutions %s are "
+                "computable from a file with %s temporal resolution".format(
+                    " ,".join(output_resolutions), time_resolution
+                )
+            )
             return []
 
         try:
             return [getattr(cdo, op)(input=data) for op in operations]
         except:
-            raise ValueError("Expected input file to have time resolution in {}, found '{}'"
-                             .format(climo_ops.keys(), time_resolution))
+            raise ValueError(
+                "Expected input file to have time resolution in {}, found '{}'".format(
+                    climo_ops.keys(), time_resolution
+                )
+            )
 
-    logger.info('Forming climatological {}s'.format(operation))
-    if var_type == 'point':
+    logger.info("Forming climatological {}s".format(operation))
+    if var_type == "point":
         # cdo can handle these variables in a single step
-        climo_files = climo_outputs(input_file.time_resolution, operation, temporal_subset, True, output_resolutions)
-    elif var_type in ['count', 'maximum', 'minimum']:
+        climo_files = climo_outputs(
+            input_file.time_resolution,
+            operation,
+            temporal_subset,
+            True,
+            output_resolutions,
+        )
+    elif var_type in ["count", "maximum", "minimum"]:
         # cdo's ymon* climatology-creating operations assume means for
         # constructing subyear aggregate datasets (like making a monthly
         # dataset from a daily dataset).
@@ -268,30 +309,59 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
         aggregations = generate_aggregates(temporal_subset, input_file, var_type)
         climo_files = []
         for res in aggregations:
-            climo_files.extend(climo_outputs(res, operation, aggregations[res], False, output_resolutions))
+            climo_files.extend(
+                climo_outputs(
+                    res, operation, aggregations[res], False, output_resolutions
+                )
+            )
 
-    elif var_type == 'duration':
+    elif var_type == "duration":
         # Sub-year aggregation cannot be performed at all with these variables.
         # We can only generate climatologies at the resolution received.
-        climo_files = climo_outputs(input_file.time_resolution, operation, temporal_subset, False, output_resolutions)
+        climo_files = climo_outputs(
+            input_file.time_resolution,
+            operation,
+            temporal_subset,
+            False,
+            output_resolutions,
+        )
 
     # Optionally concatenate values for each interval (month, season, year) into one file
     if not split_intervals and climo_files:
-        logger.info('Concatenating {} interval files'.format(operation))
-        climo_files = [cdo.copy(input=' '.join(climo_files))]
+        logger.info("Concatenating {} interval files".format(operation))
+        climo_files = [cdo.copy(input=" ".join(climo_files))]
 
     # Optionally convert longitudes in each file
     if convert_longitudes and climo_files:
-        logger.info('Converting longitudes')
-        climo_files = [convert_longitude_range(climo_file) for climo_file in climo_files]
+        logger.info("Converting longitudes")
+        climo_files = [
+            convert_longitude_range(climo_file) for climo_file in climo_files
+        ]
 
     # Convert units on any pr variable in each file
-    climo_files = [convert_flux_var_units(input_file, climo_file) for climo_file in climo_files]
+    climo_files = [
+        convert_flux_var_units(input_file, climo_file) for climo_file in climo_files
+    ]
+
+    # Record the ending time of generate_climos
+    t_end_generate_climos = generate_curr_time()
 
     # Update metadata in climo files
-    logger.debug('Updating climo metadata')
-    climo_files = [update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_file)
-                         for climo_file in climo_files]
+    logger.debug("Updating climo metadata")
+    climo_files = [
+        update_metadata_and_time_var(
+            input_file,
+            outdir,
+            filepath,
+            t_start,
+            t_end,
+            operation,
+            climo_file,
+            t_start_generate_climos,
+            t_end_generate_climos,
+        )
+        for climo_file in climo_files
+    ]
 
     # Split climo files by dependent variables if required
     if split_vars:
@@ -307,12 +377,16 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
         with CFDataset(climo_file) as cf:
             output_file_path = os.path.join(outdir, cf.cmor_filename)
         try:
-            logger.info('Output file: {}'.format(output_file_path))
+            logger.info("Output file: {}".format(output_file_path))
             if not os.path.exists(os.path.dirname(output_file_path)):
                 os.makedirs(os.path.dirname(output_file_path))
             shutil.move(climo_file, output_file_path)
         except Exception as e:
-            logger.warning('Failed to create climatology file. {}: {}'.format(e.__class__.__name__, e))
+            logger.warning(
+                "Failed to create climatology file. {}: {}".format(
+                    e.__class__.__name__, e
+                )
+            )
         else:
             output_file_paths.append(output_file_path)
 
@@ -323,7 +397,7 @@ def create_climo_files(outdir, input_file, operation, t_start, t_end,
     return output_file_paths
 
 
-def generate_climo_time_var(t_start, t_end, types={'monthly', 'seasonal', 'annual'}):
+def generate_climo_time_var(t_start, t_end, types={"monthly", "seasonal", "annual"}):
     """Generate information needed to update the climatological time variable.
 
     :param t_start: (datetime.datetime) start date of period over which climatological means/standard deviations are formed
@@ -340,7 +414,7 @@ def generate_climo_time_var(t_start, t_end, types={'monthly', 'seasonal', 'annua
     """
 
     # Year of all time values is middle year of period
-    year = (t_start + (t_end - t_start)/2).year + 1
+    year = (t_start + (t_end - t_start) / 2).year + 1
 
     # We follow the examples in sec 7.4 Climatological Statistics of the CF Metadata Standard
     # (http://cfconventions.org/cf-conventions/v1.6.0/cf-conventions.html#climatological-statistics),
@@ -351,18 +425,26 @@ def generate_climo_time_var(t_start, t_end, types={'monthly', 'seasonal', 'annua
     climo_bounds = []
 
     # Monthly time values
-    if 'monthly' in types:
+    if "monthly" in types:
         for month in range(1, 13):
             times.append(datetime(year, month, 15))
-            climo_bounds.append([datetime(t_start.year, month, 1),
-                                 datetime(t_end.year, month, 1) + relativedelta(months=1)])
+            climo_bounds.append(
+                [
+                    datetime(t_start.year, month, 1),
+                    datetime(t_end.year, month, 1) + relativedelta(months=1),
+                ]
+            )
 
     # Seasonal time values
-    if 'seasonal' in types:
+    if "seasonal" in types:
         for month in [1, 4, 7, 10]:  # Center months of season
             times.append(datetime(year, month, 16))
-            climo_bounds.append([datetime(t_start.year, month, 1) + relativedelta(months=-1),
-                                 datetime(t_end.year, month, 1) + relativedelta(months=2)])
+            climo_bounds.append(
+                [
+                    datetime(t_start.year, month, 1) + relativedelta(months=-1),
+                    datetime(t_end.year, month, 1) + relativedelta(months=2),
+                ]
+            )
 
     # Annual time value
     # Standard climatological periods, provided by nchelpers and implicit here, begin Jan 1 and end Dec 31
@@ -370,12 +452,14 @@ def generate_climo_time_var(t_start, t_end, types={'monthly', 'seasonal', 'annua
     # confirm that for 30-year means/stanard deviations, the difference in annual and
     # season averages is negligible and therefore we do not have to allow for alternate begin and end dates.
     # """
-    if 'annual' in types:
+    if "annual" in types:
         times.append(datetime(year, 7, 2))
-        climo_bounds.append([datetime(t_start.year, 1, 1),
-                             datetime(t_end.year+1, 1, 1)])
+        climo_bounds.append(
+            [datetime(t_start.year, 1, 1), datetime(t_end.year + 1, 1, 1)]
+        )
 
     return times, climo_bounds
+
 
 def generate_aggregates(data, input_file, var_type):
     """Generates aggregated datasets with resolutions [monthly, seasonal, yearly]
@@ -419,9 +503,9 @@ def convert_longitude_range(climo_data):
 
     WARNING: This code modifies the file with filepath climo_data IN PLACE.
     """
-    with CFDataset(climo_data, mode='r+') as cf:
+    with CFDataset(climo_data, mode="r+") as cf:
         convert_these = [cf.lon_var]
-        if hasattr(cf.lon_var, 'bounds'):
+        if hasattr(cf.lon_var, "bounds"):
             lon_bnds_var = cf.variables[cf.lon_var.bounds]
             convert_these.append(lon_bnds_var)
         for lon_var in convert_these:
@@ -435,41 +519,53 @@ def convert_flux_var_units(input_file, climo_data):
     """If the file contains a 'pr' or 'prsn' variable, and if its units are per
        second, convert its units to per day.
     """
-    flux_vars = [var for var in ['pr', 'prsn'] if var in input_file.dependent_varnames()]
+    flux_vars = [
+        var for var in ["pr", "prsn"] if var in input_file.dependent_varnames()
+    ]
 
     for flux_var in flux_vars:
         attributes = {}  # will contain updates, if any, to flux variable attributes
         flux_variable = input_file.variables[flux_var]
         units = Unit.from_udunits_str(flux_variable.units)
 
-        if units in [Unit('kg / m**2 / s'), Unit('mm / s')]:
+        if units in [Unit("kg / m**2 / s"), Unit("mm / s")]:
             logger.info("Converting {} variable to units mm/day".format(flux_var))
             # Update units attribute
-            attributes['units'] = (units * Unit('s / day')).to_udunits_str()
+            attributes["units"] = (units * Unit("s / day")).to_udunits_str()
             # Multiply values by 86400 to convert from mm/s to mm/day
             seconds_per_day = 86400
 
-            if hasattr(flux_variable, 'scale_factor') or hasattr(flux_variable, 'add_offset'):
+            if hasattr(flux_variable, "scale_factor") or hasattr(
+                flux_variable, "add_offset"
+            ):
                 # This is a packed file; need only modify packing parameters
                 try:
-                    attributes['scale_factor'] = seconds_per_day * flux_variable.scale_factor
+                    attributes["scale_factor"] = (
+                        seconds_per_day * flux_variable.scale_factor
+                    )
                 except AttributeError:
-                    attributes['scale_factor'] = seconds_per_day * 1.0  # default value 1.0 for missing scale factor
+                    attributes["scale_factor"] = (
+                        seconds_per_day * 1.0
+                    )  # default value 1.0 for missing scale factor
                 try:
-                    attributes['add_offset'] = seconds_per_day * flux_variable.add_offset
+                    attributes["add_offset"] = (
+                        seconds_per_day * flux_variable.add_offset
+                    )
                 except AttributeError:
-                    attributes['add_offset'] = 0.0  # default value 0.0 for missing offset
+                    attributes[
+                        "add_offset"
+                    ] = 0.0  # default value 0.0 for missing offset
             else:
                 # This is not a packed file; modify the values proper
                 # Extract variable
-                var_only = cdo.select('name={}'.format(flux_var), input=climo_data)
+                var_only = cdo.select("name={}".format(flux_var), input=climo_data)
                 # Multiply values by 86400 to convert from mm/s to mm/day
                 var_only = cdo.mulc(str(seconds_per_day), input=var_only)
                 # Replace pr in all-variables file
                 climo_data = cdo.replace(input=[climo_data, var_only])
 
         # Update pr variable metadata as necessary to reflect changes madde
-        with CFDataset(climo_data, mode='r+') as cf:
+        with CFDataset(climo_data, mode="r+") as cf:
             for attr in attributes:
                 setattr(cf.variables[flux_var], attr, attributes[attr])
 
@@ -478,15 +574,26 @@ def convert_flux_var_units(input_file, climo_data):
 
 def split_on_variables(climo_file, var_names):
     if len(var_names) > 1:
-        return [cdo.select('name={}'.format(var_name), input=climo_file)
-                for var_name in var_names]
+        return [
+            cdo.select("name={}".format(var_name), input=climo_file)
+            for var_name in var_names
+        ]
     else:
         return [climo_file]
 
 
-def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_filepath):
+def update_metadata_and_time_var(
+    input_file,
+    outdir,
+    filepath,
+    t_start,
+    t_end,
+    operation,
+    climo_filepath,
+    t_start_generate_climos,
+    t_end_generate_climos,
+):
     """Updates an existing netCDF file to reflect the fact that it contains climatological means or standard deviations.
-
     Specifically:
     - add start and end time attributes
     - update tracking_id attribute
@@ -505,16 +612,98 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
     For information on climatological statistics, and specifically on datetimes to apply to such statistics,
     see Section 7.4 of http://cfconventions.org/Data/cf-conventions/cf-conventions-1.6/build/cf-conventions.html
     """
-    with CFDataset(climo_filepath, mode='r+') as cf:
+    with CFDataset(climo_filepath, mode="r+") as cf:
         # Add start and end time attributes
         # In Python2.7, datetime.datime.isoformat does not take params telling it how much precision to
         # provide in its output; standard requires 'seconds' precision, which means the first 19 characters.
-        cf.climo_start_time = t_start.isoformat()[:19] + 'Z'
-        cf.climo_end_time = t_end.isoformat()[:19] + 'Z'
+        cf.climo_start_time = t_start.isoformat()[:19] + "Z"
+        cf.climo_end_time = t_end.isoformat()[:19] + "Z"
 
         # Update tracking_id attribute
-        if hasattr(input_file, 'tracking_id'):
+        if hasattr(input_file, "tracking_id"):
             cf.climo_tracking_id = input_file.tracking_id
+
+        def compare_times(t1, t2):
+            """This function takes two string inputs which are time representations
+            and returns boolean value. The purpose of this function is to find the
+            place where the start of generate_climos should be put in the history log.
+            It returns True if first input is later than the second input. Otherwise,
+            it returns False. If the second input is not in the format desired, the
+            function automatically returns True.
+            """
+            months = {
+                "Jan": 1,
+                "Feb": 2,
+                "Mar": 3,
+                "Apr": 4,
+                "May": 5,
+                "Jun": 6,
+                "Jul": 7,
+                "Aug": 8,
+                "Sep": 9,
+                "Oct": 10,
+                "Nov": 11,
+                "Dec": 12,
+            }
+            t1 = re.split(":|  | ", t1)
+            t2 = re.split(":|  | ", t2)
+
+            t1 = datetime(
+                int(t1[6]),
+                months[t1[1]],
+                int(t1[2]),
+                int(t1[3]),
+                int(t1[4]),
+                int(t1[5]),
+            )
+            try:
+                t2 = datetime(
+                    int(t2[6]),
+                    months[t2[1]],
+                    int(t2[2]),
+                    int(t2[3]),
+                    int(t2[4]),
+                    int(t2[5]),
+                )
+            except:
+                return True
+
+            return t1 > t2
+
+        # Update history attribute
+        if hasattr(input_file, "history"):
+            start = (
+                t_start_generate_climos
+                + ": start : generate_climos -o"
+                + outdir
+                + " "
+                + filepath
+                + " -p "
+                + operation
+            )
+            end = (
+                t_end_generate_climos
+                + ": finish : generate_climos -o"
+                + outdir
+                + " "
+                + filepath
+                + " -p "
+                + operation
+            )
+
+            history_li = cf.history.split("\n")
+            for idx, h in enumerate(history_li):
+                if compare_times(t_start_generate_climos, h[:24]):
+                    history_li.insert(idx, start)
+                    break
+
+            s = ""
+            for h in history_li:
+                s += h + "\n"
+
+            s = end + "\n" + s
+
+            cf.history = s
 
         # Deduce the set of averaging intervals from the number of times in the file.
         # WARNING: This is fragile, and depends on the assumption that a climo output file contains only the following
@@ -523,47 +712,54 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
         # This computation only works because each case results in a unique number of time values!
         try:
             num_times_to_interval_set = {
-                12: {'monthly'},
-                4: {'seasonal'},
-                1: {'annual'},
-                5: {'seasonal', 'annual'},
-                17: {'monthly', 'seasonal', 'annual'},
+                12: {"monthly"},
+                4: {"seasonal"},
+                1: {"annual"},
+                5: {"seasonal", "annual"},
+                17: {"monthly", "seasonal", "annual"},
             }
             interval_set = num_times_to_interval_set[cf.time_var.size]
         except KeyError:
-            raise ValueError('Expected climo file to contain # time values in {}, but found {}'
-                             .format(num_times_to_interval_set.keys(), cf.time_var.size))
-
+            raise ValueError(
+                "Expected climo file to contain # time values in {}, but found {}".format(
+                    num_times_to_interval_set.keys(), cf.time_var.size
+                )
+            )
 
         # Update cell_methods to reflect the operation being done to the data
         validate_operation(operation)
-        cell_method_op = {
-            'std': 'standard_deviation',
-            'mean': 'mean',
-        }[operation]
+        cell_method_op = {"std": "standard_deviation", "mean": "mean",}[operation]
 
         for key in cf.variables.keys():
             try:
-                cf.variables[key].cell_methods = cf.variables[key].cell_methods + ' time: {} over days'.format(cell_method_op)
+                cf.variables[key].cell_methods = cf.variables[
+                    key
+                ].cell_methods + " time: {} over days".format(cell_method_op)
             except AttributeError as e:
                 # skip over vars that do not have cell_methods i.e. lat, lon
                 continue
 
         # Update frequency attribute to reflect that this is a climo file.
-        suffix = {
-            'std': 'SD',
-            'mean': 'Mean',
-        }[operation]
+        suffix = {"std": "SD", "mean": "Mean",}[operation]
 
-        prefix = ''.join(abbr for interval, abbr in (('monthly', 'm'), ('seasonal', 's'), ('annual', 'a'), )
-                         if interval in interval_set)
-        cf.frequency = prefix + 'Clim' + suffix
+        prefix = "".join(
+            abbr
+            for interval, abbr in (
+                ("monthly", "m"),
+                ("seasonal", "s"),
+                ("annual", "a"),
+            )
+            if interval in interval_set
+        )
+        cf.frequency = prefix + "Clim" + suffix
 
         # Generate info for updating time variable and creating climo bounds variable
         times, climo_bounds = generate_climo_time_var(
-            dateutil.parser.parse(cf.climo_start_time[:19]),  # create tz naive dates by stripping off the tz indicator
+            dateutil.parser.parse(
+                cf.climo_start_time[:19]
+            ),  # create tz naive dates by stripping off the tz indicator
             dateutil.parser.parse(cf.climo_end_time[:19]),
-            interval_set
+            interval_set,
         )
 
         # Update time var with CF standard climatological times
@@ -573,13 +769,15 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
         # Note: CDO seems to do some automagic with bounds variable names, converting the string 'bounds' to 'bnds'.
         # For less confusion, we use that convention here, even though original code used the name 'climatology_bounds'.
         # TODO: Should this variable be added to cf.time_var.bounds?
-        cf.time_var.climatology = 'climatology_bnds'
-        if 'bnds' not in cf.dimensions:
-            cf.createDimension('bnds', 2)
-        climo_bnds_var = cf.createVariable('climatology_bnds', 'f4', ('time', 'bnds', ))
+        cf.time_var.climatology = "climatology_bnds"
+        if "bnds" not in cf.dimensions:
+            cf.createDimension("bnds", 2)
+        climo_bnds_var = cf.createVariable("climatology_bnds", "f4", ("time", "bnds",))
         climo_bnds_var.calendar = cf.time_var.calendar
         climo_bnds_var.units = cf.time_var.units
-        climo_bnds_var[:] = date2num(climo_bounds, cf.time_var.units, cf.time_var.calendar)
+        climo_bnds_var[:] = date2num(
+            climo_bounds, cf.time_var.units, cf.time_var.calendar
+        )
 
     return climo_filepath
 
@@ -590,9 +788,8 @@ def validate_operation(operation):
     operation it must be in the cdo table of statistical values.
     """
     supported_operations = {
-        'mean',
-        'std',
+        "mean",
+        "std",
     }
     if operation not in supported_operations:
-        raise Exception('Unsupported operation: can\'t yet process {}'
-                        .format(operation))
+        raise Exception("Unsupported operation: can't yet process {}".format(operation))

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -7,73 +7,123 @@ from nchelpers import CFDataset, standard_climo_periods
 from dp.argparse_helpers import strtobool, log_level_choices
 from dp.generate_climos import logger, create_climo_files
 
+
 def main(args):
     if args.dry_run:
-        logger.info('DRY RUN')
+        logger.info("DRY RUN")
         for filepath in args.filepaths:
-            logger.info('')
-            logger.info('File: {}'.format(filepath))
+            logger.info("")
+            logger.info("File: {}".format(filepath))
             try:
                 input_file = CFDataset(filepath)
             except Exception as e:
-                logger.info('{}: {}'.format(e.__class__.__name__, e))
+                logger.info("{}: {}".format(e.__class__.__name__, e))
             else:
                 periods = input_file.climo_periods.keys() & args.climo
-                logger.info('climo_periods: {}'.format(periods))
-                for attr in 'project institution model emissions run'.split():
+                logger.info("climo_periods: {}".format(periods))
+                for attr in "project institution model emissions run".split():
                     try:
-                        logger.info('{}: {}'.format(attr, getattr(input_file.metadata, attr)))
+                        logger.info(
+                            "{}: {}".format(attr, getattr(input_file.metadata, attr))
+                        )
                     except Exception as e:
-                        logger.info('{}: {}: {}'.format(attr, e.__class__.__name__, e))
-                logger.info('dependent_varnames: {}'.format(input_file.dependent_varnames()))
-                for attr in 'time_resolution is_multi_year_mean'.split():
-                    logger.info('{}: {}'.format(attr, getattr(input_file, attr)))
+                        logger.info("{}: {}: {}".format(attr, e.__class__.__name__, e))
+                logger.info(
+                    "dependent_varnames: {}".format(input_file.dependent_varnames())
+                )
+                for attr in "time_resolution is_multi_year_mean".split():
+                    logger.info("{}: {}".format(attr, getattr(input_file, attr)))
         sys.exit(0)
 
     for filepath in args.filepaths:
-        logger.info('')
-        logger.info('Processing: {}'.format(filepath))
+        logger.info("")
+        logger.info("Processing: {}".format(filepath))
         try:
             input_file = CFDataset(filepath)
         except Exception as e:
-            logger.info('{}: {}'.format(e.__class__.__name__, e))
+            logger.info("{}: {}".format(e.__class__.__name__, e))
         else:
             for period in input_file.climo_periods.keys() & args.climo:
                 t_range = input_file.climo_periods[period]
-                create_climo_files(args.outdir, input_file, args.operation, *t_range,
-                                   convert_longitudes=args.convert_longitudes, split_vars=args.split_vars,
-                                   output_resolutions=args.resolutions)
+                create_climo_files(
+                    args.outdir,
+                    filepath,
+                    input_file,
+                    args.operation,
+                    *t_range,
+                    convert_longitudes=args.convert_longitudes,
+                    split_vars=args.split_vars,
+                    output_resolutions=args.resolutions
+                )
 
-if __name__ == '__main__':
-    parser = ArgumentParser(description='Create climatologies from CMIP5 data')
-    parser.add_argument('filepaths', nargs='*', help='Files to process')
-    parser.add_argument('-c', '--climo', default=[], action='append',
-                        choices=standard_climo_periods().keys(),
-                        help='Climatological periods to generate. '
-                        'Defaults to all available in the input file. '
-                        'Ex: -c 6190 -c 7100 -c 8100 -c 2020 -c 2050 -c 2080')
-    parser.add_argument('-r', '--resolutions', default=[], action='append',
-                        choices=['yearly', 'seasonal', 'monthly'],
-                        help='Temporal resolutions of multiyear means to generate. '
-                        'Defaults to ["yearly", "seasonal", "monthly"] '
-                        'Ex: -r yearly -r seasonal')
-    parser.add_argument('-l', '--loglevel', help='Logging level',
-                        choices=log_level_choices, default='INFO')
-    parser.add_argument('-n', '--dry-run', dest='dry_run', action='store_true')
-    parser.add_argument('-g', '--convert-longitudes', type=strtobool, dest='convert_longitudes',
-                        help='Transform longitude range from [0, 360) to [-180, 180)')
-    parser.add_argument('-v', '--split-vars', type=strtobool, dest='split_vars',
-                        help='Generate a separate file for each dependent variable in the file')
-    parser.add_argument('-i', '--split-intervals', type=strtobool, dest='split_intervals',
-                        help='Generate a separate file for each climatological period')
-    parser.add_argument('-o', '--outdir', required=True, help='Output folder')
-    parser.add_argument('-p', '--operation', required=True, help='Data operation for the file',
-                        choices=['mean', 'std'])
-    parser.set_defaults(dry_run=False, convert_longitudes=True, split_vars=True, split_intervals=True)
+
+if __name__ == "__main__":
+    parser = ArgumentParser(description="Create climatologies from CMIP5 data")
+    parser.add_argument("filepaths", nargs="*", help="Files to process")
+    parser.add_argument(
+        "-c",
+        "--climo",
+        default=[],
+        action="append",
+        choices=standard_climo_periods().keys(),
+        help="Climatological periods to generate. "
+        "Defaults to all available in the input file. "
+        "Ex: -c 6190 -c 7100 -c 8100 -c 2020 -c 2050 -c 2080",
+    )
+    parser.add_argument(
+        "-r",
+        "--resolutions",
+        default=[],
+        action="append",
+        choices=["yearly", "seasonal", "monthly"],
+        help="Temporal resolutions of multiyear means to generate. "
+        'Defaults to ["yearly", "seasonal", "monthly"] '
+        "Ex: -r yearly -r seasonal",
+    )
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        help="Logging level",
+        choices=log_level_choices,
+        default="INFO",
+    )
+    parser.add_argument("-n", "--dry-run", dest="dry_run", action="store_true")
+    parser.add_argument(
+        "-g",
+        "--convert-longitudes",
+        type=strtobool,
+        dest="convert_longitudes",
+        help="Transform longitude range from [0, 360) to [-180, 180)",
+    )
+    parser.add_argument(
+        "-v",
+        "--split-vars",
+        type=strtobool,
+        dest="split_vars",
+        help="Generate a separate file for each dependent variable in the file",
+    )
+    parser.add_argument(
+        "-i",
+        "--split-intervals",
+        type=strtobool,
+        dest="split_intervals",
+        help="Generate a separate file for each climatological period",
+    )
+    parser.add_argument("-o", "--outdir", required=True, help="Output folder")
+    parser.add_argument(
+        "-p",
+        "--operation",
+        required=True,
+        help="Data operation for the file",
+        choices=["mean", "std"],
+    )
+    parser.set_defaults(
+        dry_run=False, convert_longitudes=True, split_vars=True, split_intervals=True
+    )
     args = parser.parse_args()
     if not args.climo:
         args.climo = standard_climo_periods().keys()
     if not args.resolutions:
-        args.resolutions = ['yearly', 'seasonal', 'monthly']
+        args.resolutions = ["yearly", "seasonal", "monthly"]
     logger.setLevel(getattr(logging, args.loglevel))
     main(args)


### PR DESCRIPTION
As described in issue[ #82](https://github.com/pacificclimate/climate-explorer-data-prep/issues/82), `generate_climos` did not update history attribute for its own command(while it still updated `cdo` commands ran inside `generate_climos`). For example:
```
			"Fri May 22 15:21:55 2020: cdo -O -replace /tmp/cdoPyy5na14qm /tmp/cdoPy4pzh5rv7 /tmp/cdoPy6exys6hk\n",
			"Fri May 22 15:21:54 2020: cdo -O -timmean /tmp/cdoPysbe3hq0e /tmp/cdoPyy5na14qm\n",
			"Fri May 22 15:21:54 2020: cdo -O -seldate,1961-01-01,1990-12-31 tests/data/tiny_daily_pr.nc /tmp/cdoPysbe3hq0e\n",
			"Thu Mar 21 14:49:01 2019: cdo sellonlatbox,216.5625,219.375,40.4636506825932,48.8352434707287 /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc /storage/home/nrados/tiny_daily_pr.nc\n",
			"Thu Sep  1 14:34:03 2016: ncrcat -O /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_rcp26_r1i1p1_20060101-21001231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc\n",
			"Thu Sep 01 14:33:15 2016: cdo -O seldate,1950-01-01T00:00,2005-12-31T23:59 /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc\n",
			"Thu Sep  1 14:32:42 2016: ncks -O -d lon,215.,310. -d lat,40.,85. /storage/data/climate/downscale/BCCAQ2/CMIP5/grouptmp/pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc\n",
			"2011-04-13T23:04:41Z CMOR rewrote data to comply with CF standards and CMIP5 requirements.\n",
			"" ;
```
the last 3 `cdo` commands ran as a part of `generate_climos` command,  but it is almost impossible to know the information(time & arguments) of `generate_climos` was performed on. Therefore, additional lines that describe `generate_climos' command were desired to be present in the history attribute. This commit satisfies the desired functionality by generating the following result:

```
		:history = "Fri May 22 15:21:55 2020: end : generate_climos -otests/output tests/data/tiny_daily_pr.nc -p mean\n",
			"Fri May 22 15:21:55 2020: cdo -O -replace /tmp/cdoPyy5na14qm /tmp/cdoPy4pzh5rv7 /tmp/cdoPy6exys6hk\n",
			"Fri May 22 15:21:54 2020: cdo -O -timmean /tmp/cdoPysbe3hq0e /tmp/cdoPyy5na14qm\n",
			"Fri May 22 15:21:54 2020: cdo -O -seldate,1961-01-01,1990-12-31 tests/data/tiny_daily_pr.nc /tmp/cdoPysbe3hq0e\n",
			"Fri May 22 15:21:54 2020: start : generate_climos -otests/output tests/data/tiny_daily_pr.nc -p mean\n",
			"Thu Mar 21 14:49:01 2019: cdo sellonlatbox,216.5625,219.375,40.4636506825932,48.8352434707287 /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc /storage/home/nrados/tiny_daily_pr.nc\n",
			"Thu Sep  1 14:34:03 2016: ncrcat -O /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_rcp26_r1i1p1_20060101-21001231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc\n",
			"Thu Sep 01 14:33:15 2016: cdo -O seldate,1950-01-01T00:00,2005-12-31T23:59 /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc\n",
			"Thu Sep  1 14:32:42 2016: ncks -O -d lon,215.,310. -d lat,40.,85. /storage/data/climate/downscale/BCCAQ2/CMIP5/grouptmp/pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc\n",
			"2011-04-13T23:04:41Z CMOR rewrote data to comply with CF standards and CMIP5 requirements.\n",
			"" ;
```