### PR TITLE
Issue/123  generate_climos history string inserted to history attribute when sys.argv is empty

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -243,7 +243,7 @@ def create_climo_files(
 
     # Update generate_climos history attribute
     temporal_subset = update_generate_climos_history(
-        args, temporal_subset, t_start_generate_climos, 1
+        args, temporal_subset, t_start_generate_climos, position = 1
     )
 
     # Form climatological means/standard deviations over dependent variables

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -39,6 +39,7 @@ cdo = Cdo()
 
 
 def create_climo_files(
+    climo_period,
     outdir,
     input_file,
     operation,
@@ -102,6 +103,16 @@ def create_climo_files(
     output file name will be misleading.
 
     """
+    args = {
+        "" : input_file.filepath(),
+        "-c": climo_period,
+        "-o": outdir,
+        "-p": operation,
+        "-g": str(convert_longitudes),
+        "-v": str(split_vars),
+        "-i": str(split_intervals),
+        "-r": str(output_resolutions),
+    }
 
     def curr_time_cdo_format():
         """This function returns current time in the format of
@@ -229,7 +240,7 @@ def create_climo_files(
 
     # Update generate_climos history attribute
     temporal_subset = update_generate_climos_history(
-        temporal_subset, t_start_generate_climos, 1
+        args, temporal_subset, t_start_generate_climos, 1
     )
 
     # Form climatological means/standard deviations over dependent variables
@@ -371,7 +382,7 @@ def create_climo_files(
     t_end_generate_climos = curr_time_cdo_format()
     # Update generate_climos history attribute
     climo_files = [
-        update_generate_climos_history(climo_file, t_end_generate_climos)
+        update_generate_climos_history(args, climo_file, t_end_generate_climos)
         for climo_file in climo_files
     ]
 
@@ -695,7 +706,7 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
     return climo_filepath
 
 
-def update_generate_climos_history(netCDF_file, time_cdo_format, position=0):
+def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=0):
     """This function takes the start time and end time history-attribute-lines
     of generate_climos command. It returns a string of the entire history
     attribute. The result indicates when the generate_climos started and ended.
@@ -742,10 +753,18 @@ def update_generate_climos_history(netCDF_file, time_cdo_format, position=0):
     with CFDataset(netCDF_file, "r+") as cf:
         history = cf.history
 
-        arguments_list = sys.argv
-        arguments_list[0] = ": generate_climos"
-        command = " ".join(sys.argv)
-        
+        if(len(sys.argv) > 0):
+            arguments_list = sys.argv[:]
+            arguments_list[0] = ": generate_climos"
+
+        else:
+            arguments_list = [": generate_climos"]
+            for k in args.keys():
+                arguments_list.append(k)
+                arguments_list.append(args[k])   
+
+        command = " ".join(arguments_list)
+    
         # update_generate_climos_history for the start has to be called after the first or latter cdo command
         # update_generate_climos_history for the end has to be called after the last cdo command
         if position != 0:

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -753,10 +753,10 @@ def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=
         ...
 
     """
-    # stdin input passed through terminal
+    # command line input through terminal
     if(len(sys.argv) > 1):
         arguments_list = sys.argv[1:]
-    # no stdin input provided
+    # command line input not given
     else:
         arguments_list = list(chain(*args.items()))
 

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -752,21 +752,21 @@ def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=
         ...
 
     """
+    # stdin input passed through terminal
+    if(len(sys.argv) > 1):
+        arguments_list = sys.argv[:]
+        arguments_list[0] = ": generate_climos"
+    # no stdin input provided
+    else:
+        arguments_list = [": generate_climos"]
+        for k in args.keys():
+            arguments_list.append(k)
+            arguments_list.append(args[k])   
+
+    command = " ".join(arguments_list)
+
     with CFDataset(netCDF_file, "r+") as cf:
         history = cf.history
-        
-        # stdin input passed through terminal
-        if(len(sys.argv) > 0):
-            arguments_list = sys.argv[:]
-            arguments_list[0] = ": generate_climos"
-        # no stdin input provided
-        else:
-            arguments_list = [": generate_climos"]
-            for k in args.keys():
-                arguments_list.append(k)
-                arguments_list.append(args[k])   
-
-        command = " ".join(arguments_list)
     
         # update_generate_climos_history for the start has to be called after the first or latter cdo command
         # update_generate_climos_history for the end has to be called after the last cdo command

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -103,6 +103,8 @@ def create_climo_files(
     output file name will be misleading.
 
     """
+    # args used for command line reconstruction for history attribute 
+    # when no stdin argument is given
     args = {
         "" : input_file.filepath(),
         "-c": climo_period,
@@ -752,11 +754,12 @@ def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=
     """
     with CFDataset(netCDF_file, "r+") as cf:
         history = cf.history
-
+        
+        # stdin input passed through terminal
         if(len(sys.argv) > 0):
             arguments_list = sys.argv[:]
             arguments_list[0] = ": generate_climos"
-
+        # no stdin input provided
         else:
             arguments_list = [": generate_climos"]
             for k in args.keys():

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -6,6 +6,7 @@ import shutil
 import warnings
 
 from datetime import datetime
+from itertools import chain
 import dateutil.parser
 import calendar
 import numpy as np
@@ -754,16 +755,12 @@ def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=
     """
     # stdin input passed through terminal
     if(len(sys.argv) > 1):
-        arguments_list = sys.argv[:]
-        arguments_list[0] = ": generate_climos"
+        arguments_list = sys.argv[1:]
     # no stdin input provided
     else:
-        arguments_list = [": generate_climos"]
-        for k in args.keys():
-            arguments_list.append(k)
-            arguments_list.append(args[k])   
+        arguments_list = list(chain(*args.items()))
 
-    command = " ".join(arguments_list)
+    command = ": generate_climos " + " ".join(arguments_list)
 
     with CFDataset(netCDF_file, "r+") as cf:
         history = cf.history

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -46,6 +46,7 @@ def main(args):
             for period in input_file.climo_periods.keys() & args.climo:
                 t_range = input_file.climo_periods[period]
                 create_climo_files(
+                    period,
                     args.outdir,
                     input_file,
                     args.operation,

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         scripts/generate_prsn
         scripts/split_merged_climos
         scripts/update_metadata
-		scripts/decompose_flow_vectors
+        scripts/decompose_flow_vectors
     '''.split(),
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ setup(
         scripts/generate_prsn
         scripts/split_merged_climos
         scripts/update_metadata
-	    scripts/decompose_flow_vectors
+		scripts/decompose_flow_vectors
     '''.split(),
     classifiers=[
         'Development Status :: 4 - Beta',

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,6 +1,6 @@
 from pytest import fixture, mark
 from pkg_resources import resource_filename
-from nchelpers import CFDataset
+from nchelpers import CFDataset, standard_climo_periods
 
 
 # helpers
@@ -17,6 +17,14 @@ def tiny_dataset(request):
 def outdir(tmpdir_factory):
     return str(tmpdir_factory.mktemp('outdir'))
 
+
+@fixture(scope='function')
+def period(request):
+    input_dataset = get_dataset(request.param)
+    if (len(input_dataset.climo_periods.keys()) > 0):
+        return list(input_dataset.climo_periods.keys() & standard_climo_periods().keys())[0]
+    else:
+        return ""
 
 @fixture(scope='function')
 def datasets():

--- a/tests/test_create_climo_files.py
+++ b/tests/test_create_climo_files.py
@@ -56,16 +56,16 @@ def basename_components(filepath):
 
 # Tests
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'mean', t_start(1965), t_end(1970)),
-    ('gcm_360_day_cal', 'std', t_start(1965), t_end(1970)),  # test date processing
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'mean', t_start(1971), t_end(2000)),  # test seasonal-only
-    ('tr_annual', 'mean', t_start(1961), t_end(1990)),  # test annual-only
-    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm','gcm', 'mean', t_start(1965), t_end(1970)),
+    ('gcm_360_day_cal', 'gcm_360_day_cal', 'std', t_start(1965), t_end(1970)),  # test date processing
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
+    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
+    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1971), t_end(2000)),  # test seasonal-only
+    ('tr_annual', 'tr_annual', 'mean', t_start(1961), t_end(1990)),  # test annual-only
+    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
+], indirect=['tiny_dataset', 'period'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -74,11 +74,11 @@ def basename_components(filepath):
     False,
     True,
 ])
-def test_existence(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_existence(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
     """Test that the expected number of files was created and that the filenames returned by
     create_climo_files are those actually created.
     """
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
     num_vars = len(tiny_dataset.dependent_varnames())
     num_files = 1
@@ -92,14 +92,14 @@ def test_existence(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
     assert set(climo_files) == set(os.path.join(outdir, f) for f in os.listdir(outdir))
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'mean', t_start(1961), t_end(1990)),
-    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm','gcm', 'std', t_start(1965), t_end(1970)),
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
+    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
+    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1961), t_end(1990)),
+    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -108,14 +108,14 @@ def test_existence(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
     False,
     True,
 ])
-def test_filenames(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_filenames(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
     """Test that the filenames are as expected. Tests only the following easy-to-test filename components:
     - variable name
     - frequency
     Testing all the components of the filenames would be a lot of work and would duplicate unit tests for
     the filename generator in nchelpers.
     """
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
     if split_vars:
         varnames = set(tiny_dataset.dependent_varnames())
@@ -132,15 +132,15 @@ def test_filenames(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
             assert frequency in 'aClim aClimSD aClimMean saClim saClimSD saClimMean msaClim msaClimSD msaClimMean'.split()
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'mean', t_start(1981), t_end(2010)),
-    ('tr_annual', 'std', t_start(1960), t_end(1970)),
-    ('daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
+    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
+    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1981), t_end(2010)),
+    ('tr_annual', 'tr_annual', 'std', t_start(1960), t_end(1970)),
+    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -149,9 +149,9 @@ def test_filenames(outdir, tiny_dataset, operation, t_start, t_end, split_vars, 
     False,
     True,
 ])
-def test_climo_metadata(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_climo_metadata(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
     """Test that the correct climo-specific metadata has been added/updated."""
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
     frequencies = set()
 
@@ -205,17 +205,17 @@ def test_climo_metadata(outdir, tiny_dataset, operation, t_start, t_end, split_v
         }[tiny_dataset.time_resolution]
 
 
-@mark.parametrize('tiny_dataset, comparison', [
-    ('gdd_seasonal', 'greatermean'),
-    ('fd_monthly', 'greatermean'),
-    ('txx_monthly', 'greatermin'),
-    ('tnn_monthly', 'lessermax')
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, comparison', [
+    ('gdd_seasonal', 'gdd_seasonal', 'greatermean'),
+    ('fd_monthly', 'fd_monthly', 'greatermean'),
+    ('txx_monthly', 'txx_monthly', 'greatermin'),
+    ('tnn_monthly', 'tnn_monthly', 'lessermax')
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('t_start, t_end', [
     (t_start(1971), t_end(2000)),
     (t_start(2010), t_end(2039))
     ])
-def test_variable_aggregation(outdir, tiny_dataset, comparison, t_start, t_end):
+def test_variable_aggregation(period, outdir, tiny_dataset, comparison, t_start, t_end):
     """Test that the values for variables aggregated within a year are
     in the expected range. For these variables, the value of a year is
     *not* the mean of the monthly or seasonal values. Checks to make
@@ -237,7 +237,7 @@ def test_variable_aggregation(outdir, tiny_dataset, comparison, t_start, t_end):
         "greatermin": lambda a, b: a.min() > b.min(),
         "lessermax": lambda a, b: a.max() < b.max()
         }[comparison]
-    climo_files = create_climo_files(outdir, tiny_dataset, "mean",
+    climo_files = create_climo_files(period, outdir, tiny_dataset, "mean",
                                      t_start, t_end, split_vars=False,
                                      split_intervals=True)
     for cf in climo_files:
@@ -255,15 +255,15 @@ def test_variable_aggregation(outdir, tiny_dataset, comparison, t_start, t_end):
                     assert test(outvar, invar)
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('wsdi_annual', 'mean', t_start(2010), t_end(2039)),
-    ('wsdi_annual', 'std', t_start(1961), t_end(1990))
-    ], indirect=['tiny_dataset'])
-def test_duration_variable_resolutions(outdir, tiny_dataset, operation, t_start, t_end):
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('wsdi_annual', 'wsdi_annual', 'mean', t_start(2010), t_end(2039)),
+    ('wsdi_annual', 'wsdi_annual', 'std', t_start(1961), t_end(1990))
+    ], indirect=['period', 'tiny_dataset'])
+def test_duration_variable_resolutions(period, outdir, tiny_dataset, operation, t_start, t_end):
     """Datasets with duration variables (values measuring the number of
     consecutive days something happens) cannot be aggregated into coarser
     time values. Test that output resolution matches input resolution."""
-    climo_files = create_climo_files(outdir, tiny_dataset, operation,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
                                      t_start, t_end, split_vars=False,
                                      split_intervals=False)
     for cf in climo_files:
@@ -271,11 +271,11 @@ def test_duration_variable_resolutions(outdir, tiny_dataset, operation, t_start,
             assert tiny_dataset.time_resolution == output.time_resolution
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end, var', [
-    ('downscaled_pr', 'mean', t_start(1965), t_end(1970), 'pr'),
-    ('downscaled_pr_packed', 'std', t_start(1965), t_end(1970), 'pr'),
-    ('daily_prsn', 'mean', t_start(1950), t_end(2100), 'prsn'),
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end, var', [
+    ('downscaled_pr', 'downscaled_pr', 'mean', t_start(1965), t_end(1970), 'pr'),
+    ('downscaled_pr_packed', 'downscaled_pr_packed', 'std', t_start(1965), t_end(1970), 'pr'),
+    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100), 'prsn'),
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -284,12 +284,12 @@ def test_duration_variable_resolutions(outdir, tiny_dataset, operation, t_start,
     False,
     True,
 ])
-def test_pr_units_conversion(outdir, tiny_dataset, operation, t_start, t_end, var, split_vars, split_intervals):
+def test_pr_units_conversion(period, outdir, tiny_dataset, operation, t_start, t_end, var, split_vars, split_intervals):
     """Test that units conversion for 'pr' variable is performed properly, for both packed and unpacked files.
     Test for unpacked file is pretty elementary: check pr units.
     Test for packed checks that packing params are modified correctly.
     """
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
 
     assert var in tiny_dataset.dependent_varnames()
@@ -312,13 +312,13 @@ def test_pr_units_conversion(outdir, tiny_dataset, operation, t_start, t_end, va
                         assert output_pr_var.add_offset == 0.0
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'mean', t_start(1971), t_end(2000))
-], indirect=['tiny_dataset'])
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
+    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
+    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1971), t_end(2000))
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -327,9 +327,9 @@ def test_pr_units_conversion(outdir, tiny_dataset, operation, t_start, t_end, va
     False,
     True,
 ])
-def test_dependent_variables(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_dependent_variables(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
     """Test that the output files contain the expected dependent variables"""
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
     dependent_varnames_in_cfs = set()
     for fp in climo_files:
@@ -342,12 +342,12 @@ def test_dependent_variables(outdir, tiny_dataset, operation, t_start, t_end, sp
     assert dependent_varnames_in_cfs == set(tiny_dataset.dependent_varnames())
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'mean', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm', 'gcm', 'mean', t_start(1965), t_end(1970)),
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
     # No need to repleat with downscaled_pr
-    ('hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-], indirect=['tiny_dataset'])
+    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -356,9 +356,9 @@ def test_dependent_variables(outdir, tiny_dataset, operation, t_start, t_end, sp
     False,
     True,
 ])
-def test_time_and_climo_bounds_vars(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+def test_time_and_climo_bounds_vars(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
     """Test that the climo output files contain the expected time values and climo bounds. """
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals)
 
     for fp in climo_files:
@@ -424,12 +424,12 @@ def test_time_and_climo_bounds_vars(outdir, tiny_dataset, operation, t_start, t_
                 assert cb[1] == d2n(datetime(t_end.year+1, 1, 1))
 
 
-@mark.parametrize('tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
+@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
+    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
+    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
     # No need to repleat with downscaled_pr
-    ('hydromodel_gcm', 'std', t_start(1984), t_end(1995)),
-], indirect=['tiny_dataset'])
+    ('hydromodel_gcm', 'hydromodel_gcm', 'std', t_start(1984), t_end(1995)),
+], indirect=['period', 'tiny_dataset'])
 @mark.parametrize('split_vars', [
     False,
     True,
@@ -442,9 +442,9 @@ def test_time_and_climo_bounds_vars(outdir, tiny_dataset, operation, t_start, t_
     False,
     True,
 ])
-def test_convert_longitudes(outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals, convert_longitudes):
+def test_convert_longitudes(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals, convert_longitudes):
     """Test that longitude conversion is performed correctly."""
-    climo_files = create_climo_files(outdir, tiny_dataset, operation, t_start, t_end,
+    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
                                      split_vars=split_vars, split_intervals=split_intervals,
                                      convert_longitudes=convert_longitudes)
     input_lon_var = tiny_dataset.lon_var[:]
@@ -479,7 +479,7 @@ def test_convert_longitudes(outdir, tiny_dataset, operation, t_start, t_end, spl
 def test_resolution_filter(outdir, datasets, resolutions, split_intervals):
     tiny_dataset = datasets['tasmax']
     climo_files = create_climo_files(
-        outdir, tiny_dataset, 'mean', t_start(1965), t_end(1970),
+        "", outdir, tiny_dataset, 'mean', t_start(1965), t_end(1970),
         split_vars=False, split_intervals=split_intervals,
         convert_longitudes=False, output_resolutions=resolutions
     )
@@ -491,16 +491,16 @@ def test_resolution_filter(outdir, datasets, resolutions, split_intervals):
         assert len(climo_files) == min(1, len(resolutions))
 
 
-@mark.parametrize(('tiny_dataset'), [
-    'tr_annual'
-], indirect=['tiny_dataset'])
-def test_resolution_warning(outdir, tiny_dataset):
+@mark.parametrize(('period, tiny_dataset'), [
+    ('tr_annual','tr_annual')
+], indirect=['period', 'tiny_dataset'])
+def test_resolution_warning(period, outdir, tiny_dataset):
     '''If we try to compute a monthly climo from an annual file
        there should be zero output files and a warning issued
     '''
     with warns(Warning) as record:
         climo_files = create_climo_files(
-            outdir, tiny_dataset, 'mean', t_start(1965),
+            period, outdir, tiny_dataset, 'mean', t_start(1965),
             t_end(1971), split_vars=True, split_intervals=True,
             convert_longitudes=True, output_resolutions={'monthly'}
         )


### PR DESCRIPTION
This PR closes #123 

A new pathway to update history metadata attribute has been implemented in `generate_climos` for broader usage of `create_climo_files` in other programs. As described in the issue, updating the history attribute did not function properly when no argument was passed through terminal standard input since sys.argv was used for command-line reconstruction. This problem is solved by the creation of `args` dictionary that has keys as options and values as arguments. When sys.argv is empty, the program reconstructs the command-line using the information in the `args` dictionary. Additionally, `create_climo_files` function takes the parameter of the Climatological period option(`-c`/`--climo` ) for an informative history record.

`tmp.py` used for testing:
```
from nchelpers import CFDataset, standard_climo_periods
from dp.generate_climos import create_climo_files

filepath = "./tests/data/tiny_daily_pr.nc"
input_file = CFDataset(filepath)
climo = standard_climo_periods().keys()
for period in input_file.climo_periods.keys() & climo:
    t_range = input_file.climo_periods[period]
    create_climo_files(
                    period,
                    "output",
                    input_file,
                    "mean",
                    *t_range,
                    )
```

An example output using the new pathway:
```
		:history = "Tue Jun 16 10:21:05 2020: end: generate_climos  ./tests/data/tiny_daily_pr.nc -c 2050 -o output -p mean -g True -v True -i True -r {\'seasonal\', \'yearly\', \'monthly\'}\n",
			"Tue Jun 16 10:21:04 2020: cdo -O -replace /tmp/cdoPyitmuee4a /tmp/cdoPyo_3lyoua /tmp/cdoPy32cxq5jv\n",
			"Tue Jun 16 10:21:04 2020: cdo -O -ymonmean /tmp/cdoPys4ypc09c /tmp/cdoPyitmuee4a\n",
			"Tue Jun 16 10:21:03 2020: cdo -O -seldate,2040-01-01,2069-12-31 ./tests/data/tiny_daily_pr.nc /tmp/cdoPys4ypc09c\n",
			"Tue Jun 16 10:21:03 2020: start: generate_climos  ./tests/data/tiny_daily_pr.nc -c 2050 -o output -p mean -g True -v True -i True -r {\'seasonal\', \'yearly\', \'monthly\'}\n",
			"Thu Mar 21 14:49:01 2019: cdo sellonlatbox,216.5625,219.375,40.4636506825932,48.8352434707287 /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc /storage/home/nrados/tiny_daily_pr.nc\n",
			"Thu Sep  1 14:34:03 2016: ncrcat -O /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_rcp26_r1i1p1_20060101-21001231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/CanESM2/pr_day_CanESM2_historical+rcp26_r1i1p1_19500101-21001231.nc\n",
			"Thu Sep 01 14:33:15 2016: cdo -O seldate,1950-01-01T00:00,2005-12-31T23:59 /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/timetmp/time_subset_pr_day_CanESM2_historical_r1i1p1_19500101-20051231.nc\n",
			"Thu Sep  1 14:32:42 2016: ncks -O -d lon,215.,310. -d lat,40.,85. /storage/data/climate/downscale/BCCAQ2/CMIP5/grouptmp/pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc /storage/data/climate/downscale/BCCAQ2/CMIP5/spacetmp/space_subset_pr_day_CanESM2_historical_r1i1p1_18500101-20051231.nc\n",
			"2011-04-13T23:04:41Z CMOR rewrote data to comply with CF standards and CMIP5 requirements." ;
```