### PR TITLE
Issue/126 Refactor input validity checks in decompose_flow_vectors

### DIFF
--- a/dp/decompose_flow_vectors.py
+++ b/dp/decompose_flow_vectors.py
@@ -23,14 +23,19 @@ def check_and_raise_exception(condition, source, err_msg, exc):
         raise exc(err_msg)
 
 
+def dimensions_validity(dimensions):
+    return not "lon" in dimensions or not "lat" in dimensions
+
+
 def source_check(source):
     source_file_path = source.filepath()
 
-    condition = not "lon" in source.dimensions or not "lat" in source.dimensions
     err_msg = "{} does not have latitude and longitude dimensions".format(
         source_file_path
     )
-    check_and_raise_exception(condition, source, err_msg, AttributeError)
+    check_and_raise_exception(
+        dimensions_validity(source.dimensions), source, err_msg, AttributeError
+    )
 
     valid_variables = []
     for v in source.variables:
@@ -57,11 +62,10 @@ def variable_check(source, variable):
 
     flow_variable = source.variables[variable]
 
-    condition = (
-        not "lon" in flow_variable.dimensions or not "lat" in flow_variable.dimensions
-    )
     err_msg = "Variable {} is not associated with a grid".format(variable)
-    check_and_raise_exception(condition, source, err_msg, AttributeError)
+    check_and_raise_exception(
+        dimensions_validity(flow_variable.dimensions), source, err_msg, AttributeError
+    )
 
     condition = np.ma.max(flow_variable[:]) > 9 or np.ma.min(flow_variable[:]) < 1
     err_msg = "Variable {} is not a valid flow routing".format(variable)

--- a/dp/decompose_flow_vectors.py
+++ b/dp/decompose_flow_vectors.py
@@ -34,9 +34,8 @@ def dimensions_validity(variable):
 def source_check(source):
     source_file_path = source.filepath()
 
-    condition = dimensions_validity(source)
     check_for_exception(
-        condition,
+        dimensions_validity(source),
         source,
         AttributeError,
         err_msg="{} does not have latitude and longitude dimensions".format(
@@ -55,9 +54,8 @@ def source_check(source):
         )
     ]
 
-    condition = len(valid_variables) > 0
     check_for_exception(
-        condition,
+        (len(valid_variables) > 0),
         source,
         ValueError,
         err_msg="{} does not have a valid flow variable".format(source_file_path),
@@ -67,9 +65,8 @@ def source_check(source):
 def variable_check(source, variable):
     source_file_path = source.filepath()
 
-    condition = variable in source.variables
     check_for_exception(
-        condition,
+        (variable in source.variables),
         source,
         AttributeError,
         err_msg="Variable {} is not found in {}".format(variable, source_file_path),
@@ -77,17 +74,15 @@ def variable_check(source, variable):
 
     flow_variable = source.variables[variable]
 
-    condition = dimensions_validity(flow_variable)
     check_for_exception(
-        condition,
+        dimensions_validity(flow_variable),
         source,
         AttributeError,
         err_msg="Variable {} is not associated with a grid".format(variable),
     )
 
-    condition = np.ma.max(flow_variable[:]) <= 9 and np.ma.min(flow_variable[:]) >= 1
     check_for_exception(
-        condition,
+        (np.ma.max(flow_variable[:]) <= 9 and np.ma.min(flow_variable[:]) >= 1),
         source,
         ValueError,
         err_msg="Variable {} is not a valid flow routing".format(variable),

--- a/dp/decompose_flow_vectors.py
+++ b/dp/decompose_flow_vectors.py
@@ -38,9 +38,7 @@ def source_check(source):
         dimensions_validity(source),
         source,
         AttributeError,
-        err_msg="{} does not have latitude and longitude dimensions".format(
-            source_file_path
-        ),
+        err_msg=f"{source_file_path} does not have latitude and longitude dimensions",
     )
 
     variables = source.variables
@@ -58,7 +56,7 @@ def source_check(source):
         (len(valid_variables) > 0),
         source,
         ValueError,
-        err_msg="{} does not have a valid flow variable".format(source_file_path),
+        err_msg=f"{source_file_path} does not have a valid flow variable",
     )
 
 
@@ -69,7 +67,7 @@ def variable_check(source, variable):
         (variable in source.variables),
         source,
         AttributeError,
-        err_msg="Variable {} is not found in {}".format(variable, source_file_path),
+        err_msg=f"Variable {variable} is not found in {source_file_path}",
     )
 
     flow_variable = source.variables[variable]
@@ -78,14 +76,14 @@ def variable_check(source, variable):
         dimensions_validity(flow_variable),
         source,
         AttributeError,
-        err_msg="Variable {} is not associated with a grid".format(variable),
+        err_msg=f"Variable {variable} is not associated with a grid",
     )
 
     check_for_exception(
         (np.ma.max(flow_variable[:]) <= 9 and np.ma.min(flow_variable[:]) >= 1),
         source,
         ValueError,
-        err_msg="Variable {} is not a valid flow routing".format(variable),
+        err_msg=f"Variable {variable} is not a valid flow routing",
     )
 
 
@@ -116,13 +114,7 @@ def decompose_flow_vectors(source, dest_file, variable):
     # update history attribute, if present, to include this script
     if "history" in dest.ncattrs():
         dest.history = (
-            "{} {} {} {} {}\n".format(
-                time.ctime(time.time()),
-                "decompose_flow_vectors",
-                source.filepath(),
-                dest_file,
-                variable,
-            )
+            f"{time.ctime(time.time())} decompose_flow_vectors {source.filepath()} {dest_file} {variable}\n"
             + dest.history
         )
 
@@ -154,13 +146,13 @@ def create_vector_variables(direction, dest, variable):
     :param dest: (str) path to destination netCDF file
     :param variable: (str) netCDF variable describing flow direction
     """
-    dir_vec = "{}ward_{}".format(direction, variable)
+    dir_vec = f"{direction}ward_{variable}"
     dest.createVariable(dir_vec, "f8", ("lat", "lon"))
     dest.variables[dir_vec].units = "1"
     dest.variables[dir_vec].standard_name = dir_vec  # ncWMS relies on standard names
     dest.variables[
         dir_vec
-    ].long_name = "Normalized {}ward vector component of {}".format(direction, variable)
+    ].long_name = f"Normalized {direction}ward vector component of {variable}"
 
     return dir_vec
 
@@ -195,7 +187,7 @@ def generate_vector_component(dir_vec, source, dest, variable):
     two_grids = {"eastward": 1, "northward": 0}
 
     grid_dir = dir_vec.split("_")[0]
-    logger.info("Generating {} component".format(grid_dir))
+    logger.info(f"Generating {grid_dir} component")
     grid_idx = two_grids[grid_dir]
 
     # vectors_field is consist of VIC Routing Directional Vector Values

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -14,7 +14,7 @@ import sys
 from dp.decompose_flow_vectors import logger, decompose_flow_vectors
 from dp.argparse_helpers import log_level_choices
 
-# NoDimensionsError and NoFlowVariablesError inherits InvalidSourceError
+# NoDimensionsError and NoFlowVariablesError inherit InvalidSourceError
 class InvalidSourceError(Exception):
     pass
 
@@ -27,7 +27,7 @@ class NoFlowVariablesError(InvalidSourceError):
     pass
 
 
-# VariableNotFoundError, NotAFlowVariableError and NotAVicModelError inherits InvalidVariableError
+# VariableNotFoundError, NotAFlowVariableError and NotAVicModelError inherit InvalidVariableError
 class InvalidVariableError(Exception):
     pass
 

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -14,37 +14,101 @@ import sys
 from dp.decompose_flow_vectors import logger, decompose_flow_vectors
 from dp.argparse_helpers import log_level_choices
 
+# NoDimensionsError and NoFlowVariablesError inherits InvalidSourceError
+class InvalidSourceError(Exception):
+    pass
+
+
+class NoDimensionsError(InvalidSourceError):
+    pass
+
+
+class NoFlowVariablesError(InvalidSourceError):
+    pass
+
+
+# VariableNotFoundError, NotAFlowVariableError and NotAVicModelError inherits InvalidVariableError
+class InvalidVariableError(Exception):
+    pass
+
+
+class VariableNotFoundError(InvalidVariableError):
+    pass
+
+
+class NotAFlowVariableError(InvalidVariableError):
+    pass
+
+
+class NotAVicModelError(InvalidVariableError):
+    pass
+
+
+def source_check(source):
+    source_file_path = source.filepath()
+
+    if not "lon" in source.dimensions or not "lat" in source.dimensions:
+        logger.critical(
+            "{} does not have latitude and longitude dimensions".format(
+                source_file_path
+            )
+        )
+        raise NoDimensionsError
+
+    valid_variables = []
+    for v in source.variables:
+        variable = source.variables[v]
+        if (
+            hasattr(variable, "dimensions")
+            and "lon" in variable.dimensions
+            and "lat" in variable.dimensions
+        ):
+            if np.ma.max(variable[:]) <= 9 and np.ma.min(variable[:]) >= 1:
+                valid_variables.append(v)
+
+    if len(valid_variables) == 0:
+        logger.critical(
+            "{} does not have a valid flow variable".format(source_file_path)
+        )
+        source.close()
+        raise NoFlowVariablesError
+
+
+def variable_check(source, variable):
+    source_file_path = source.filepath()
+
+    if not variable in source.variables:
+        logger.critical(
+            "Variable {} is not found in {}".format(variable, source_file_path)
+        )
+        source.close()
+        raise VariableNotFoundError
+
+    flow_variable = source.variables[variable]
+
+    if not "lon" in flow_variable.dimensions or not "lat" in flow_variable.dimensions:
+        logger.critical("Variable {} is not associated with a grid".format(variable))
+        source.close()
+        raise NotAFlowVariableError
+
+    if np.ma.max(flow_variable[:]) > 9 or np.ma.min(flow_variable[:]) < 1:
+        logger.critical("Variable {} is not a valid flow routing".format(variable))
+        source.close()
+        raise NotAVicModelError
+
 
 def main(args):
     # check that source file is usable:
     source = Dataset(args.source_file, "r", format="NETCDF4")
 
-    if not "lon" in source.dimensions or not "lat" in source.dimensions:
-        logger.debug(
-            "{} does not have latitude and longitude dimensions".format(
-                args.source_file
-            )
-        )
-        source.close()
+    try:
+        source_check(source)
+    except InvalidSourceError:
         sys.exit()
 
-    if not args.variable in source.variables:
-        logger.debug(
-            "Variable {} is not found in {}".format(args.variable, args.source_file)
-        )
-        source.close()
-        sys.exit()
-
-    flow_variable = source.variables[args.variable]
-
-    if not "lon" in flow_variable.dimensions or not "lat" in flow_variable.dimensions:
-        logger.debug("Variable {} is not associated with a grid".format(args.variable))
-        source.close()
-        sys.exit()
-
-    if np.ma.max(flow_variable[:]) > 9 or np.ma.min(flow_variable[:]) < 1:
-        logger.debug("Variable {} is not a valid flow routing".format(args.variable))
-        source.close()
+    try:
+        variable_check(source, args.variable)
+    except InvalidVariableError:
         sys.exit()
 
     decompose_flow_vectors(source, args.dest_file, args.variable)
@@ -59,8 +123,13 @@ if __name__ == "__main__":
     parser.add_argument(
         "variable", metavar="variable", help="netCDF variable describing flow direction"
     )
-    parser.add_argument('-l', '--loglevel', help='Logging level',
-                        choices=log_level_choices, default='INFO')
+    parser.add_argument(
+        "-l",
+        "--loglevel",
+        help="Logging level",
+        choices=log_level_choices,
+        default="INFO",
+    )
 
     args = parser.parse_args()
     logger.setLevel(getattr(logging, args.loglevel))

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -104,12 +104,12 @@ def main(args):
     try:
         source_check(source)
     except InvalidSourceError:
-        sys.exit()
+        sys.exit(1)
 
     try:
         variable_check(source, args.variable)
     except InvalidVariableError:
-        sys.exit()
+        sys.exit(2)
 
     decompose_flow_vectors(source, args.dest_file, args.variable)
 

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -11,57 +11,13 @@ import logging
 from netCDF4 import Dataset
 import numpy as np
 import sys
-from dp.decompose_flow_vectors import logger, decompose_flow_vectors
+from dp.decompose_flow_vectors import (
+    logger,
+    decompose_flow_vectors,
+    source_check,
+    variable_check,
+)
 from dp.argparse_helpers import log_level_choices
-
-
-def log_and_raise_exception(source, err_msg, exc):
-    logger.critical(err_msg)
-    source.close()
-    raise exc(err_msg)
-
-
-def source_check(source):
-    source_file_path = source.filepath()
-
-    if not "lon" in source.dimensions or not "lat" in source.dimensions:
-        err_msg = "{} does not have latitude and longitude dimensions".format(
-            source_file_path
-        )
-        log_and_raise_exception(source, err_msg, AttributeError)
-
-    valid_variables = []
-    for v in source.variables:
-        variable = source.variables[v]
-        if (
-            hasattr(variable, "dimensions")
-            and "lon" in variable.dimensions
-            and "lat" in variable.dimensions
-        ):
-            if np.ma.max(variable[:]) <= 9 and np.ma.min(variable[:]) >= 1:
-                valid_variables.append(v)
-
-    if len(valid_variables) == 0:
-        err_msg = "{} does not have a valid flow variable".format(source_file_path)
-        log_and_raise_exception(source, err_msg, ValueError)
-
-
-def variable_check(source, variable):
-    source_file_path = source.filepath()
-
-    if not variable in source.variables:
-        err_msg = "Variable {} is not found in {}".format(variable, source_file_path)
-        log_and_raise_exception(source, err_msg, AttributeError)
-
-    flow_variable = source.variables[variable]
-
-    if not "lon" in flow_variable.dimensions or not "lat" in flow_variable.dimensions:
-        err_msg = "Variable {} is not associated with a grid".format(variable)
-        log_and_raise_exception(source, err_msg, AttributeError)
-
-    if np.ma.max(flow_variable[:]) > 9 or np.ma.min(flow_variable[:]) < 1:
-        err_msg = "Variable {} is not a valid flow routing".format(variable)
-        log_and_raise_exception(source, err_msg, ValueError)
 
 
 def main(args):

--- a/scripts/decompose_flow_vectors
+++ b/scripts/decompose_flow_vectors
@@ -14,46 +14,21 @@ import sys
 from dp.decompose_flow_vectors import logger, decompose_flow_vectors
 from dp.argparse_helpers import log_level_choices
 
-# NoDimensionsError and NoFlowVariablesError inherit InvalidSourceError
-class InvalidSourceError(Exception):
-    pass
 
-
-class NoDimensionsError(InvalidSourceError):
-    pass
-
-
-class NoFlowVariablesError(InvalidSourceError):
-    pass
-
-
-# VariableNotFoundError, NotAFlowVariableError and NotAVicModelError inherit InvalidVariableError
-class InvalidVariableError(Exception):
-    pass
-
-
-class VariableNotFoundError(InvalidVariableError):
-    pass
-
-
-class NotAFlowVariableError(InvalidVariableError):
-    pass
-
-
-class NotAVicModelError(InvalidVariableError):
-    pass
+def log_and_raise_exception(source, err_msg, exc):
+    logger.critical(err_msg)
+    source.close()
+    raise exc(err_msg)
 
 
 def source_check(source):
     source_file_path = source.filepath()
 
     if not "lon" in source.dimensions or not "lat" in source.dimensions:
-        logger.critical(
-            "{} does not have latitude and longitude dimensions".format(
-                source_file_path
-            )
+        err_msg = "{} does not have latitude and longitude dimensions".format(
+            source_file_path
         )
-        raise NoDimensionsError
+        log_and_raise_exception(source, err_msg, AttributeError)
 
     valid_variables = []
     for v in source.variables:
@@ -67,34 +42,26 @@ def source_check(source):
                 valid_variables.append(v)
 
     if len(valid_variables) == 0:
-        logger.critical(
-            "{} does not have a valid flow variable".format(source_file_path)
-        )
-        source.close()
-        raise NoFlowVariablesError
+        err_msg = "{} does not have a valid flow variable".format(source_file_path)
+        log_and_raise_exception(source, err_msg, ValueError)
 
 
 def variable_check(source, variable):
     source_file_path = source.filepath()
 
     if not variable in source.variables:
-        logger.critical(
-            "Variable {} is not found in {}".format(variable, source_file_path)
-        )
-        source.close()
-        raise VariableNotFoundError
+        err_msg = "Variable {} is not found in {}".format(variable, source_file_path)
+        log_and_raise_exception(source, err_msg, AttributeError)
 
     flow_variable = source.variables[variable]
 
     if not "lon" in flow_variable.dimensions or not "lat" in flow_variable.dimensions:
-        logger.critical("Variable {} is not associated with a grid".format(variable))
-        source.close()
-        raise NotAFlowVariableError
+        err_msg = "Variable {} is not associated with a grid".format(variable)
+        log_and_raise_exception(source, err_msg, AttributeError)
 
     if np.ma.max(flow_variable[:]) > 9 or np.ma.min(flow_variable[:]) < 1:
-        logger.critical("Variable {} is not a valid flow routing".format(variable))
-        source.close()
-        raise NotAVicModelError
+        err_msg = "Variable {} is not a valid flow routing".format(variable)
+        log_and_raise_exception(source, err_msg, ValueError)
 
 
 def main(args):
@@ -103,12 +70,12 @@ def main(args):
 
     try:
         source_check(source)
-    except InvalidSourceError:
+    except (AttributeError, ValueError):
         sys.exit(1)
 
     try:
         variable_check(source, args.variable)
-    except InvalidVariableError:
+    except (AttributeError, ValueError):
         sys.exit(2)
 
     decompose_flow_vectors(source, args.dest_file, args.variable)

--- a/tests/test_decompose_flow_vectors.py
+++ b/tests/test_decompose_flow_vectors.py
@@ -1,71 +1,120 @@
 """Tests for the decompose_flow_vectors script. Create a small netCDF
    file, run the script, and check its output."""
-   
+
 from netCDF4 import Dataset
+import pytest
 import datetime
 import subprocess
 import os
 import numpy as np
 import numpy.ma as ma
+import pkg_resources
 
 
 def create_routing_file(name, numlats, numlons, routes):
     """Creates a simple netCDF file with latlon and flows.
     Requires numlats and numlons to be divisors of 15."""
     testfile = Dataset(name, "w", format="NETCDF4")
-    
+
     lat = testfile.createDimension("lat", numlats)
     lon = testfile.createDimension("lon", numlons)
-    
+
     lats = testfile.createVariable("lat", "f8", ("lat"))
     lons = testfile.createVariable("lon", "f8", ("lon"))
     flows = testfile.createVariable("flow", "f8", ("lat", "lon"))
-    
+
     lats[:] = range(45, 60, int(15 / numlats))
     lons[:] = range(-125, -110, int(15 / numlons))
     flows[:] = routes
-    
+
     testfile.close()
+
 
 def test_decomposition():
     timestamp = datetime.datetime.now().microsecond
     infile = "testinput{}.nc".format(timestamp)
     outfile = "testoutput{}.nc".format(timestamp)
     create_routing_file(infile, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
-    
-    subprocess.call(["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"])
-    
-    output = Dataset(outfile, "r", format = "NETCDF4")
+
+    subprocess.call(
+        ["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"]
+    )
+
+    output = Dataset(outfile, "r", format="NETCDF4")
     north = output.variables["northward_flow"][:]
     east = output.variables["eastward_flow"][:]
-    
-    assert(np.array_equal(north, np.array([[1., 0.7071, 0.], [-.7071, -1., -.7071], [0., .7071, 0.]])))
-    assert(np.array_equal(east, np.array([[0, 0.7071, 1], [.7071, 0, -.7071], [-1, -.7071, 0]])))
-    
+
+    assert np.array_equal(
+        north,
+        np.array([[1.0, 0.7071, 0.0], [-0.7071, -1.0, -0.7071], [0.0, 0.7071, 0.0]]),
+    )
+    assert np.array_equal(
+        east, np.array([[0, 0.7071, 1], [0.7071, 0, -0.7071], [-1, -0.7071, 0]])
+    )
+
     output.close()
     os.remove(infile)
     os.remove(outfile)
+
 
 def test_missing_data():
     timestamp = datetime.datetime.now().microsecond
     infile = "testinput{}.nc".format(timestamp)
     outfile = "testoutput{}.nc".format(timestamp)
-    
-    arr = np.array([1., 2, 3, 4, 5, 6, 7, 8, 9])
-    marr = ma.masked_array(arr, mask=[0, 0, 0, 1, 0, 0, 0, 0, 0] )
+
+    arr = np.array([1.0, 2, 3, 4, 5, 6, 7, 8, 9])
+    marr = ma.masked_array(arr, mask=[0, 0, 0, 1, 0, 0, 0, 0, 0])
     create_routing_file(infile, 3, 3, marr)
-    
-    subprocess.call(["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"])
-    
+
+    subprocess.call(
+        ["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"]
+    )
+
     output = Dataset(outfile, "r", format="NetCDF4")
     north = output.variables["northward_flow"][:]
-    assert(np.ma.is_masked(north[1][0]))
-    
+    assert np.ma.is_masked(north[1][0])
+
     east = output.variables["eastward_flow"][:]
-    assert(np.ma.is_masked(east[1][0]))
-    
+    assert np.ma.is_masked(east[1][0])
+
     output.close()
     os.remove(infile)
     os.remove(outfile)
 
-    
+
+def test_source_check():
+    timestamp = datetime.datetime.now().microsecond
+    infile = "testinput{}.nc".format(timestamp)
+    outfile = "testoutput{}.nc".format(timestamp)
+    create_routing_file(infile, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 15])
+
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        subprocess.check_call(
+            ["python", "./scripts/decompose_flow_vectors", infile, outfile, "flow"]
+        )
+    assert e.type == subprocess.CalledProcessError
+    assert e.value.returncode == 1
+
+    os.remove(infile)
+
+
+def test_variable_check():
+    timestamp = datetime.datetime.now().microsecond
+    infile = "testinput{}.nc".format(timestamp)
+    outfile = "testoutput{}.nc".format(timestamp)
+    create_routing_file(infile, 3, 3, [1, 2, 3, 4, 5, 6, 7, 8, 9])
+
+    with pytest.raises(subprocess.CalledProcessError) as e:
+        subprocess.check_call(
+            [
+                "python",
+                "./scripts/decompose_flow_vectors",
+                infile,
+                outfile,
+                "invalid_variable_name",
+            ]
+        )
+    assert e.type == subprocess.CalledProcessError
+    assert e.value.returncode == 2
+
+    os.remove(infile)


### PR DESCRIPTION
This PR closes issue #126 

For the convenience in importing `decompose_flow_vectors` in other programs such as WPS processes, the input validity checking procedure in main() has been refactored into `source_check` and `variable_check` functions. The advantage of the functions is that they do not need terminal input for arguments, thus they can be called in any programs that do not require terminal inputs.

The functions throw an user-defined exception if any error conditions are met, and main() `SystemExit`s the program when it catches an exception. There are two main user-defined exceptions(InvalidSourceError and InvalidVariableError) and 5 other exceptions that inherit the main exceptions. The reason for having many specific exceptions is to manage versatile error conditions when the functions are called in other programs