### PR TITLE
Flexible logging out strategy for generate_climos dry_run

### DIFF
--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -51,7 +51,7 @@ def input_check(filepath, climo, outputer=logger.info):
     The function returns CFDataset and list.
     If any of the checks are not passed, the function returns None and empty list.
     """
-    outputer("File: {}".format(filepath))
+    outputer(f"File: {filepath}")
 
     try:
         input_file = CFDataset(filepath)
@@ -60,7 +60,7 @@ def input_check(filepath, climo, outputer=logger.info):
         return None, []
 
     periods = input_file.climo_periods.keys() & climo
-    outputer("climo_periods: {}".format(periods))
+    outputer(f"climo_periods: {periods}")
     if len(periods) == 0:
         logger.critical(
             f"{input_file.filepath()} contains no standard climatological periods"
@@ -91,17 +91,17 @@ def dry_run_handler(filepath, climo, outpath=None):
 
     for attr in ["project", "institution", "model", "emissions", "run"]:
         try:
-            outputer("{}: {}".format(attr, getattr(input_file.metadata, attr)))
+            outputer(f"{attr}: {getattr(input_file.metadata, attr)}")
         except Exception as e:
-            outputer("{}: {}: {}".format(attr, e.__class__.__name__, e))
+            outputer(f"{attr}: {e.__class__.__name__}: {e}")
     outputer("dependent_varnames: {}".format(input_file.dependent_varnames()))
     for attr in ["time_resolution", "is_multi_year_mean"]:
-        outputer("{}: {}".format(attr, getattr(input_file, attr)))
+        outputer(f"{attr}: {getattr(input_file, attr)}")
 
     if outpath:
         with open(outpath, "w") as f:
             for line in output_items:
-                f.write("{}\n".format(line))
+                f.write(f"{line}\n")
 
 
 def generate_climos(

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -63,7 +63,7 @@ def input_check(filepath, climo, outputer=logger.info):
     outputer(f"climo_periods: {periods}")
     if len(periods) == 0:
         logger.critical(
-            f"{input_file.filepath()} contains no standard climatological periods"
+            f"{input_file.filepath()} contains no standard climatological periods {climo}"
         )
         return None, []
 

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -94,7 +94,7 @@ def dry_run_handler(filepath, climo, outpath=None):
             outputer(f"{attr}: {getattr(input_file.metadata, attr)}")
         except Exception as e:
             outputer(f"{attr}: {e.__class__.__name__}: {e}")
-    outputer("dependent_varnames: {}".format(input_file.dependent_varnames()))
+    outputer(f"dependent_varnames: {input_file.dependent_varnames()}")
     for attr in ["time_resolution", "is_multi_year_mean"]:
         outputer(f"{attr}: {getattr(input_file, attr)}")
 

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -67,8 +67,9 @@ if __name__ == "__main__":
     parser.add_argument("-n", "--dry-run", dest="dry_run", action="store_true")
     parser.add_argument(
         "-f",
-        "--dry-output-to-file",
+        "--dry-file",
         dest="dry_output_to_file",
+        action="store_true",
         help="Outputs dry run info to a file",
     )
     parser.add_argument(
@@ -76,6 +77,7 @@ if __name__ == "__main__":
         "--convert-longitudes",
         type=strtobool,
         dest="convert_longitudes",
+        default=True,
         help="Transform longitude range from [0, 360) to [-180, 180)",
     )
     parser.add_argument(
@@ -83,6 +85,7 @@ if __name__ == "__main__":
         "--split-vars",
         type=strtobool,
         dest="split_vars",
+        default=True,
         help="Generate a separate file for each dependent variable in the file",
     )
     parser.add_argument(
@@ -90,6 +93,7 @@ if __name__ == "__main__":
         "--split-intervals",
         type=strtobool,
         dest="split_intervals",
+        default=True,
         help="Generate a separate file for each climatological period",
     )
     parser.add_argument("-o", "--outdir", required=True, help="Output folder")
@@ -100,17 +104,13 @@ if __name__ == "__main__":
         help="Data operation for the file",
         choices=["mean", "std"],
     )
-    parser.set_defaults(
-        dry_run=False,
-        dry_output_to_file=False,
-        convert_longitudes=True,
-        split_vars=True,
-        split_intervals=True,
-    )
+
     args = parser.parse_args()
+
     if not args.climo:
         args.climo = standard_climo_periods().keys()
     if not args.resolutions:
         args.resolutions = ["yearly", "seasonal", "monthly"]
+
     logger.setLevel(getattr(logging, args.loglevel))
     main(args)

--- a/scripts/generate_climos
+++ b/scripts/generate_climos
@@ -1,6 +1,7 @@
 #!python
 from argparse import ArgumentParser
 import logging
+import os
 import sys
 
 from nchelpers import CFDataset, standard_climo_periods
@@ -10,9 +11,14 @@ from dp.generate_climos import logger, generate_climos, dry_run_handler
 
 def main(args):
     if args.dry_run:
-        logger.info("DRY RUN")
         for filepath in args.filepaths:
-            dry_run_handler(filepath, args.climo)
+            filename = filepath.split("/")[-1][:-3]
+            outpath = (
+                os.path.join(args.outdir, filename + "_dry_run.txt")
+                if args.dry_output_to_file
+                else None
+            )
+            dry_run_handler(filepath, args.climo, outpath)
         sys.exit(0)
 
     for filepath in args.filepaths:
@@ -60,6 +66,12 @@ if __name__ == "__main__":
     )
     parser.add_argument("-n", "--dry-run", dest="dry_run", action="store_true")
     parser.add_argument(
+        "-f",
+        "--dry-output-to-file",
+        dest="dry_output_to_file",
+        help="Outputs dry run info to a file",
+    )
+    parser.add_argument(
         "-g",
         "--convert-longitudes",
         type=strtobool,
@@ -89,7 +101,11 @@ if __name__ == "__main__":
         choices=["mean", "std"],
     )
     parser.set_defaults(
-        dry_run=False, convert_longitudes=True, split_vars=True, split_intervals=True
+        dry_run=False,
+        dry_output_to_file=False,
+        convert_longitudes=True,
+        split_vars=True,
+        split_intervals=True,
     )
     args = parser.parse_args()
     if not args.climo:


### PR DESCRIPTION
This PR resolves #135 

For the convenience of `thunderbird`'s `wps_generate_climos` dry_run output, [dry_run_helper](https://github.com/pacificclimate/climate-explorer-data-prep/blob/i135/dp/generate_climos.py#L73) in `generate_climos.py` follows the similar logging strategy of `generate_prsn.py`'s [dry_run](https://github.com/pacificclimate/climate-explorer-data-prep/blob/master/dp/generate_prsn.py#L22)