### PR TITLE
Revert generate_prsn back to when it did not have file output for dry_run

### DIFF
--- a/README.md
+++ b/README.md
@@ -398,8 +398,8 @@ To generate a file containing the `snowfall_flux` from input files of precipiati
 #### Usage:
 
 ```bash
-# Metadata check
-generate_prsn --metadata-check -p prec_file -n tasmin_file -x tasmax_file -o outdir
+# Dry run
+generate_prsn --dry-run -p prec_file -n tasmin_file -x tasmax_file -o outdir
 
 # File generation
 generate_prsn -p prec_file -n tasmin_file -x tasmax_file -o outdir

--- a/dp/generate_prsn.py
+++ b/dp/generate_prsn.py
@@ -25,7 +25,7 @@ def dry_run(filepaths):
        Parameters:
             filepaths (dict): Dictionary containing the three filepaths
     '''
-    logger.inf('Dry Run')
+    logger.info('Dry Run')
     for filepath in filepaths.values():
         logger.info('')
         logger.info('File: {}'.format(filepath))

--- a/dp/generate_prsn.py
+++ b/dp/generate_prsn.py
@@ -28,18 +28,18 @@ def dry_run(filepaths):
     logger.info('Dry Run')
     for filepath in filepaths.values():
         logger.info('')
-        logger.info('File: {}'.format(filepath))
+        logger.info(f'File: {filepath}')
         try:
             dataset = CFDataset(filepath)
         except Exception as e:
-            logger.exception('{}: {}'.format(e.__class__.__name__, e))
+            logger.exception(f'{e.__class__.__name__}: {e}')
 
         for attr in 'project model institute experiment ensemble_member'.split():
             try:
-                logger.info('{}: {}'.format(attr, getattr(dataset.metadata, attr)))
+                logger.info(f'{attr}: {getattr(dataset.metadata, attr)}')
             except Exception as e:
-                logger.info('{}: {}: {}'.format(attr, e.__class__.__name__, e))
-        logger.info('dependent_varnames: {}'.format(dataset.dependent_varnames()))
+                logger.info(f'{attr}: {e.__class__.__name__}: {e}')
+        logger.info(f'dependent_varnames: {dataset.dependent_varnames()}')
 
 
 def unique_shape(arrays):

--- a/dp/generate_prsn.py
+++ b/dp/generate_prsn.py
@@ -19,38 +19,28 @@ Q_ = ureg.Quantity
 logger = logging.getLogger(__name__)
 
 
-def dry_run(filepaths, outpath=None):
+def dry_run(filepaths):
     '''Perform metadata checks on the input files
 
        Parameters:
             filepaths (dict): Dictionary containing the three filepaths
-            outpath (str): Optional path to text file that will contain metadata info
     '''
-    if outpath: # Used for wps process in thunderbird
-        output_items = []
-        outputer = output_items.append
-    else:
-        outputer = logger.info
-
-    outputer('Dry Run')
+    logger.inf('Dry Run')
     for filepath in filepaths.values():
-        outputer('File: {}'.format(filepath))
+        logger.info('')
+        logger.info('File: {}'.format(filepath))
         try:
             dataset = CFDataset(filepath)
         except Exception as e:
-            outputer('{}: {}'.format(e.__class__.__name__, e))
+            logger.exception('{}: {}'.format(e.__class__.__name__, e))
 
         for attr in 'project model institute experiment ensemble_member'.split():
             try:
-                outputer('{}: {}'.format(attr, getattr(dataset.metadata, attr)))
+                logger.info('{}: {}'.format(attr, getattr(dataset.metadata, attr)))
             except Exception as e:
-                outputer('{}: {}: {}'.format(attr, e.__class__.__name__, e))
-        outputer('dependent_varnames: {}'.format(dataset.dependent_varnames()))
+                logger.info('{}: {}: {}'.format(attr, e.__class__.__name__, e))
+        logger.info('dependent_varnames: {}'.format(dataset.dependent_varnames()))
 
-    if outpath:
-        with open(outpath, 'w') as f:
-            for line in output_items:
-                f.write('{}\n'.format(line))
 
 def unique_shape(arrays):
     '''Ensure each array in dict is the same shape'''

--- a/scripts/generate_prsn
+++ b/scripts/generate_prsn
@@ -1,7 +1,6 @@
 #!python
 from argparse import ArgumentParser
 import logging
-import os
 
 from dp.generate_prsn import generate_prsn_file, dry_run
 from nchelpers import CFDataset
@@ -24,8 +23,7 @@ def main(args):
         'tasmax': args.tasmax
     }
     if args.dry_run:
-        outpath = os.path.join(args.outdir, args.dry_output_file) if args.dry_output_file else None
-        dry_run(filepaths, outpath)
+        dry_run(filepaths)
     else:
         generate_prsn_file(filepaths, args.chunk_size, args.outdir, args.output_file)
 
@@ -33,8 +31,6 @@ def main(args):
 if __name__ == '__main__':
     parser = ArgumentParser(description='Create precipitation as snow data from pr, tasmin, tasmax')
     parser.add_argument('-d', '--dry-run', dest='dry_run', action='store_true')
-    parser.add_argument('-r', '--dry-output-file', dest='dry_output_file', default=None,
-                        help='Optional name of text file to contain dry run info')
     parser.add_argument('-c', '--chunk-size', dest='chunk_size', type=int, default=100,
                         help='Number of time slices to be read/written at a time')
     parser.add_argument('-p', '--prec', required=True, help='Precipitation file to process')


### PR DESCRIPTION
This PR closes #137 

This PR removes redundant argument `output_to_file` from `generate_prsn`, which produces a file with `dry_run` info.