### PR TITLE
Modernize Installation

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,10 @@
+## Changes
+Can be a paragraph or:
+- bullet
+- points
+
+Resolves #[issue]
+
+## Checklist
+- [ ] Full integration tests are passing locally
+- [ ] Docs have been updated to reflect the changes

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,15 @@
+name: Lint
+
+on: push
+
+jobs:
+  black:
+
+    runs-on: ubuntu-20.04
+    
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+      - uses: psf/black@stable
+        with:
+          black_args: ". --check"

--- a/.github/workflows/pypi-publish.yml
+++ b/.github/workflows/pypi-publish.yml
@@ -8,18 +8,20 @@ on:
 jobs:
   publish:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
 
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python
       uses: actions/setup-python@v2
       with:
-        python-version: '3.6'
+        python-version: '3.8'
+
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
         pip install setuptools wheel twine
+        
     - name: Build and publish
       env:
         TWINE_USERNAME: ${{ secrets.pcic_at_pypi_username }}

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -24,23 +24,18 @@ jobs:
         sudo apt-get install cdo
         pip install -U pip pipenv
 
-    - id: cache-pipenv
-      uses: actions/cache@v2
-      with:
-        path: ~/.local/share/virtualenvs
-        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
-
-    - name: Install dependencies if changed
-      if: steps.cache-pipenv.outputs.cache-hit != 'true'
+    - name: Install python packages
       run: |
-        pipenv install --dev
+        pipenv lock --requirements > requirements.txt
+        pipenv lock --requirements --dev >> requirements.txt
+        pip install -r requirements.txt
 
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        pipenv run py.test -v
+        py.test -v
     
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        pipenv run py.test -m "not slow" -v
+        py.test -m "not slow" -v

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.7, 3.8]
+        python-version: [3.6, 3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -22,20 +22,33 @@ jobs:
         sudo apt-get update
         sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
         sudo apt-get install cdo
-        pip install -U pip pipenv
 
-    - name: Install python packages
+    - name: Install pipenv
       run: |
-        pipenv lock --requirements > requirements.txt
-        pipenv lock --requirements --dev >> requirements.txt
-        pip install -r requirements.txt
+        pip install -U pipenv
+    
+    - id: cache-pipenv
+      uses: actions/cache@v2
+      with:
+        path: ~/.local/share/virtualenvs
+        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
 
+    - name: Install dependencies if changed
+      if: steps.cache-pipenv.outputs.cache-hit != 'true' && ${{ matrix.python-version == '3.8' }}
+      run: |
+        pipenv install --deploy --dev
+    - name: Re-install dependencies if alternative python version
+      if: ${{ matrix.python-version != '3.8' }}
+      run: |
+        mv Pipfile.lock do-not-use
+        pipenv install --python ${{ matrix.python-version }} --dev
+    
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        py.test -v
+        pipenv run py.test -m "not online" -v
     
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not slow" -v
+        pipenv run py.test -m "not online and not slow" -v

--- a/.github/workflows/python-ci.yml
+++ b/.github/workflows/python-ci.yml
@@ -5,10 +5,10 @@ on: push
 jobs:
   test:
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-20.04
     strategy:
       matrix:
-        python-version: [3.6, 3.7]
+        python-version: [3.7, 3.8]
 
     steps:
     - uses: actions/checkout@v2
@@ -16,21 +16,31 @@ jobs:
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
+
     - name: Install dependencies
-      env:
-        PIP_INDEX_URL: https://pypi.pacificclimate.org/simple
       run: |
         sudo apt-get update
         sudo apt-get install libhdf5-serial-dev netcdf-bin libnetcdf-dev
         sudo apt-get install cdo
-        pip install -U pip pytest
-        pip install -r requirements.txt
-        pip install .
+        pip install -U pip pipenv
+
+    - id: cache-pipenv
+      uses: actions/cache@v2
+      with:
+        path: ~/.local/share/virtualenvs
+        key: ${{ runner.os }}-pipenv-${{ hashFiles('**/Pipfile.lock') }}
+
+    - name: Install dependencies if changed
+      if: steps.cache-pipenv.outputs.cache-hit != 'true'
+      run: |
+        pipenv install --dev
+
     - name: Test with pytest (full)
       if: github.ref == 'refs/heads/master'
       run: |
-        py.test -v
+        pipenv run py.test -v
+    
     - name: Test with pytest (fast)
       if: github.ref != 'refs/heads/master'
       run: |
-        py.test -m "not slow" -v
+        pipenv run py.test -m "not slow" -v

--- a/Pipfile
+++ b/Pipfile
@@ -18,6 +18,7 @@ PyYAML = "*"
 [dev-packages]
 pytest = "*"
 pytest-mock = "*"
+black = "==21.7b0"
 
 [requires]
 python_version = "3.8"

--- a/Pipfile
+++ b/Pipfile
@@ -1,0 +1,27 @@
+[[source]]
+url = "https://pypi.python.org/simple"
+verify_ssl = true
+name = "pypi"
+
+[[source]]
+url = "https://pypi.pacificclimate.org/simple"
+verify_ssl = true
+name = "pcic"
+
+[packages]
+python-dateutil = "*"
+cdo = "==1.5.3"
+nchelpers = "==5.5.6"
+Pint = "*"
+PyYAML = "*"
+
+[dev-packages]
+pytest = "*"
+pytest-mock = "*"
+
+[requires]
+python_version = "3.8"
+
+[packages.e1839a8]
+path = "."
+editable = true

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,0 +1,250 @@
+{
+    "_meta": {
+        "hash": {
+            "sha256": "f46ce05dcdf97444899cc70317ce017d6c7d86c84f4a9595ac3eb338efa8f39d"
+        },
+        "pipfile-spec": 6,
+        "requires": {
+            "python_version": "3.8"
+        },
+        "sources": [
+            {
+                "name": "pypi",
+                "url": "https://pypi.python.org/simple",
+                "verify_ssl": true
+            },
+            {
+                "name": "pcic",
+                "url": "https://pypi.pacificclimate.org/simple",
+                "verify_ssl": true
+            }
+        ]
+    },
+    "default": {
+        "cached-property": {
+            "hashes": [
+                "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130",
+                "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"
+            ],
+            "version": "==1.5.2"
+        },
+        "cdo": {
+            "hashes": [
+                "sha256:b35b872046c3bd98e9d325882197df6f4c4b92c0602bb2ce4bb3af645b0cdb4f"
+            ],
+            "index": "pypi",
+            "version": "==1.5.3"
+        },
+        "e1839a8": {
+            "editable": true,
+            "path": "."
+        },
+        "nchelpers": {
+            "hashes": [
+                "sha256:83c8252035310226d9ac048bc63a4fa6f2034a70ed08970075404bb9fba3e936",
+                "sha256:c51478302e1838c6f894c1553dfe4121573a4d30d2e0f5320482279925d39d92"
+            ],
+            "index": "pypi",
+            "version": "==5.5.6"
+        },
+        "netcdf4": {
+            "hashes": [
+                "sha256:03cefa19970b13e5b42f2ada1b871a64730af12296689e87bc262d424cb0626c",
+                "sha256:0fda3cfa9bb91d1b82d642427dd51a5d590a9b650ebdcf1009104f64b5887878",
+                "sha256:10257b8fbbfc38acdd00bbd39c16f7800682baeea5949dc4e6a7b07b6af2de03",
+                "sha256:1982372aeacc6b36054d90d8cb54ee9506b66b6f44d5cff10e2ffb162aad5476",
+                "sha256:19ac7a31aaad220327e33ec51efbb772d184cc61a602e3830dbe903ab34f0a28",
+                "sha256:223173966c0c6e58dd99306623bdcebf71227dd0fb8353b52c67cd066c533ef8",
+                "sha256:25b86488f23430b14ba28850e181ad8d84ee0985c2a04a7c5857289115218aa6",
+                "sha256:25fc45889fe6ca027285bd2c664e6578ddc5adc14483f9111e3fb07a7ee9bedc",
+                "sha256:2aab895406d9fb83aac1f924faaa6654a7282983e35561bb4ace7f77b39b6b09",
+                "sha256:32085e0011a6b0c47d28028701781e2b98a73b8e00c175ead4b0677f7e79532e",
+                "sha256:382434cfca2e9301d39d6deb697b8ffd5a5a10ffb1dd5dc67b35bbe105d93700",
+                "sha256:3fde7e6727ebf35e1eaf66f3359e8fe3849fea245cde4abbc1e258759e7de2ca",
+                "sha256:4963883c3ee70aa44287b889eff7db7034b8cae220748a9ebe6841a2db15de53",
+                "sha256:51bd9824287bcf1e412f54ebc46a02315d6b52b4b8fa87d15c16a49151e253bb",
+                "sha256:689002f1341c8e4ad9f56fa60977f0077bacd9b133ec328150545c31e51f825a",
+                "sha256:746206077bd1b2ee9c2cbb389c929ff1de0655ab38a5874212f500d8d6bdf5a8",
+                "sha256:7ce39b506d8db54ad7768f9b2bad3461df820046768aa25b8afc02512a686b5c",
+                "sha256:aa955987616b0746f7403b16f0ebd3c362c8273ad442a0f6ac281c0a396dafaf",
+                "sha256:b49b914c6b0bdd9cc5ac38d7110fce7194a1ad0978ba267a3ee9eeab317933a5",
+                "sha256:c02c65f076fa15999969285411ab1446ed420ce24546272b27670bd16dd877a6",
+                "sha256:ca9ec711aabf452f6c9467add8f45a3a9ada1566fc9e7d8f5a05ee0abf142bbe",
+                "sha256:d85850f8fdc064b83886f2a38f085192f9aaf62df649e35f98a3c024e26816a1"
+            ],
+            "version": "==1.3"
+        },
+        "numpy": {
+            "hashes": [
+                "sha256:01721eefe70544d548425a07c80be8377096a54118070b8a62476866d5208e33",
+                "sha256:0318c465786c1f63ac05d7c4dbcecd4d2d7e13f0959b01b534ea1e92202235c5",
+                "sha256:05a0f648eb28bae4bcb204e6fd14603de2908de982e761a2fc78efe0f19e96e1",
+                "sha256:1412aa0aec3e00bc23fbb8664d76552b4efde98fb71f60737c83efbac24112f1",
+                "sha256:25b40b98ebdd272bc3020935427a4530b7d60dfbe1ab9381a39147834e985eac",
+                "sha256:2d4d1de6e6fb3d28781c73fbde702ac97f03d79e4ffd6598b880b2d95d62ead4",
+                "sha256:38e8648f9449a549a7dfe8d8755a5979b45b3538520d1e735637ef28e8c2dc50",
+                "sha256:4a3d5fb89bfe21be2ef47c0614b9c9c707b7362386c9a3ff1feae63e0267ccb6",
+                "sha256:635e6bd31c9fb3d475c8f44a089569070d10a9ef18ed13738b03049280281267",
+                "sha256:73101b2a1fef16602696d133db402a7e7586654682244344b8329cdcbbb82172",
+                "sha256:791492091744b0fe390a6ce85cc1bf5149968ac7d5f0477288f78c89b385d9af",
+                "sha256:7a708a79c9a9d26904d1cca8d383bf869edf6f8e7650d85dbc77b041e8c5a0f8",
+                "sha256:88c0b89ad1cc24a5efbb99ff9ab5db0f9a86e9cc50240177a571fbe9c2860ac2",
+                "sha256:8a326af80e86d0e9ce92bcc1e65c8ff88297de4fa14ee936cb2293d414c9ec63",
+                "sha256:8a92c5aea763d14ba9d6475803fc7904bda7decc2a0a68153f587ad82941fec1",
+                "sha256:91c6f5fc58df1e0a3cc0c3a717bb3308ff850abdaa6d2d802573ee2b11f674a8",
+                "sha256:95b995d0c413f5d0428b3f880e8fe1660ff9396dcd1f9eedbc311f37b5652e16",
+                "sha256:9749a40a5b22333467f02fe11edc98f022133ee1bfa8ab99bda5e5437b831214",
+                "sha256:978010b68e17150db8765355d1ccdd450f9fc916824e8c4e35ee620590e234cd",
+                "sha256:9a513bd9c1551894ee3d31369f9b07460ef223694098cf27d399513415855b68",
+                "sha256:a75b4498b1e93d8b700282dc8e655b8bd559c0904b3910b144646dbbbc03e062",
+                "sha256:c6a2324085dd52f96498419ba95b5777e40b6bcbc20088fddb9e8cbb58885e8e",
+                "sha256:d7a4aeac3b94af92a9373d6e77b37691b86411f9745190d2c351f410ab3a791f",
+                "sha256:d9e7912a56108aba9b31df688a4c4f5cb0d9d3787386b87d504762b6754fbb1b",
+                "sha256:dff4af63638afcc57a3dfb9e4b26d434a7a602d225b42d746ea7fe2edf1342fd",
+                "sha256:e46ceaff65609b5399163de5893d8f2a82d3c77d5e56d976c8b5fb01faa6b671",
+                "sha256:f01f28075a92eede918b965e86e8f0ba7b7797a95aa8d35e1cc8821f5fc3ad6a",
+                "sha256:fd7d7409fa643a91d0a05c7554dd68aa9c9bb16e186f6ccfe40d6e003156e33a"
+            ],
+            "version": "==1.21.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "version": "==21.0"
+        },
+        "pint": {
+            "hashes": [
+                "sha256:6593c5dfaf2f701c54f17453191dff05e90ec9ebc3d1901468a59cfcb3289a4c",
+                "sha256:f4d0caa713239e6847a7c6eefe2427358566451fe56497d533f21fb590a3f313"
+            ],
+            "index": "pypi",
+            "version": "==0.17"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "python-dateutil": {
+            "hashes": [
+                "sha256:0123cacc1627ae19ddf3c27a5de5bd67ee4586fbdd6440d9748f8abb483d3e86",
+                "sha256:961d03dc3453ebbc59dbdea9e4e11c5651520a876d0f4db161e8674aae935da9"
+            ],
+            "index": "pypi",
+            "version": "==2.8.2"
+        },
+        "pyyaml": {
+            "hashes": [
+                "sha256:08682f6b72c722394747bddaf0aa62277e02557c0fd1c42cb853016a38f8dedf",
+                "sha256:0f5f5786c0e09baddcd8b4b45f20a7b5d61a7e7e99846e3c799b05c7c53fa696",
+                "sha256:129def1b7c1bf22faffd67b8f3724645203b79d8f4cc81f674654d9902cb4393",
+                "sha256:294db365efa064d00b8d1ef65d8ea2c3426ac366c0c4368d930bf1c5fb497f77",
+                "sha256:3b2b1824fe7112845700f815ff6a489360226a5609b96ec2190a45e62a9fc922",
+                "sha256:3bd0e463264cf257d1ffd2e40223b197271046d09dadf73a0fe82b9c1fc385a5",
+                "sha256:4465124ef1b18d9ace298060f4eccc64b0850899ac4ac53294547536533800c8",
+                "sha256:49d4cdd9065b9b6e206d0595fee27a96b5dd22618e7520c33204a4a3239d5b10",
+                "sha256:4e0583d24c881e14342eaf4ec5fbc97f934b999a6828693a99157fde912540cc",
+                "sha256:5accb17103e43963b80e6f837831f38d314a0495500067cb25afab2e8d7a4018",
+                "sha256:607774cbba28732bfa802b54baa7484215f530991055bb562efbed5b2f20a45e",
+                "sha256:6c78645d400265a062508ae399b60b8c167bf003db364ecb26dcab2bda048253",
+                "sha256:72a01f726a9c7851ca9bfad6fd09ca4e090a023c00945ea05ba1638c09dc3347",
+                "sha256:74c1485f7707cf707a7aef42ef6322b8f97921bd89be2ab6317fd782c2d53183",
+                "sha256:895f61ef02e8fed38159bb70f7e100e00f471eae2bc838cd0f4ebb21e28f8541",
+                "sha256:8c1be557ee92a20f184922c7b6424e8ab6691788e6d86137c5d93c1a6ec1b8fb",
+                "sha256:bb4191dfc9306777bc594117aee052446b3fa88737cd13b7188d0e7aa8162185",
+                "sha256:bfb51918d4ff3d77c1c856a9699f8492c612cde32fd3bcd344af9be34999bfdc",
+                "sha256:c20cfa2d49991c8b4147af39859b167664f2ad4561704ee74c1de03318e898db",
+                "sha256:cb333c16912324fd5f769fff6bc5de372e9e7a202247b48870bc251ed40239aa",
+                "sha256:d2d9808ea7b4af864f35ea216be506ecec180628aced0704e34aca0b040ffe46",
+                "sha256:d483ad4e639292c90170eb6f7783ad19490e7a8defb3e46f97dfe4bacae89122",
+                "sha256:dd5de0646207f053eb0d6c74ae45ba98c3395a571a2891858e87df7c9b9bd51b",
+                "sha256:e1d4970ea66be07ae37a3c2e48b5ec63f7ba6804bdddfdbd3cfd954d25a82e63",
+                "sha256:e4fac90784481d221a8e4b1162afa7c47ed953be40d31ab4629ae917510051df",
+                "sha256:fa5ae20527d8e831e8230cbffd9f8fe952815b2b7dae6ffec25318803a7528fc",
+                "sha256:fd7f6999a8070df521b6384004ef42833b9bd62cfee11a09bda1079b4b704247",
+                "sha256:fdc842473cd33f45ff6bce46aea678a54e3d21f1b61a7750ce3c498eedfe25d6",
+                "sha256:fe69978f3f768926cfa37b867e3843918e012cf83f680806599ddce33c2c68b0"
+            ],
+            "index": "pypi",
+            "version": "==5.4.1"
+        },
+        "six": {
+            "hashes": [
+                "sha256:1e61c37477a1626458e36f7b1d82aa5c9b094fa4802892072e49de9c60c4c926",
+                "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"
+            ],
+            "version": "==1.16.0"
+        }
+    },
+    "develop": {
+        "attrs": {
+            "hashes": [
+                "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
+                "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
+            ],
+            "version": "==21.2.0"
+        },
+        "iniconfig": {
+            "hashes": [
+                "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3",
+                "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"
+            ],
+            "version": "==1.1.1"
+        },
+        "packaging": {
+            "hashes": [
+                "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
+                "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
+            ],
+            "version": "==21.0"
+        },
+        "pluggy": {
+            "hashes": [
+                "sha256:15b2acde666561e1298d71b523007ed7364de07029219b604cf808bfa1c765b0",
+                "sha256:966c145cd83c96502c3c3868f50408687b38434af77734af1e9ca461a4081d2d"
+            ],
+            "version": "==0.13.1"
+        },
+        "py": {
+            "hashes": [
+                "sha256:21b81bda15b66ef5e1a777a21c4dcd9c20ad3efd0b3f817e7a809035269e1bd3",
+                "sha256:3b80836aa6d1feeaa108e046da6423ab8f6ceda6468545ae8d02d9d58d18818a"
+            ],
+            "version": "==1.10.0"
+        },
+        "pyparsing": {
+            "hashes": [
+                "sha256:c203ec8783bf771a155b207279b9bccb8dea02d8f0c9e5f8ead507bc3246ecc1",
+                "sha256:ef9d7589ef3c200abe66653d3f1ab1033c3c419ae9b9bdb1240a85b024efc88b"
+            ],
+            "version": "==2.4.7"
+        },
+        "pytest": {
+            "hashes": [
+                "sha256:50bcad0a0b9c5a72c8e4e7c9855a3ad496ca6a881a3641b4260605450772c54b",
+                "sha256:91ef2131a9bd6be8f76f1f08eac5c5317221d6ad1e143ae03894b862e8976890"
+            ],
+            "index": "pypi",
+            "version": "==6.2.4"
+        },
+        "pytest-mock": {
+            "hashes": [
+                "sha256:30c2f2cc9759e76eee674b81ea28c9f0b94f8f0445a1b87762cadf774f0df7e3",
+                "sha256:40217a058c52a63f1042f0784f62009e976ba824c418cced42e88d5f40ab0e62"
+            ],
+            "index": "pypi",
+            "version": "==3.6.1"
+        },
+        "toml": {
+            "hashes": [
+                "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
+                "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
+            ],
+            "version": "==0.10.2"
+        }
+    }
+}

--- a/Pipfile.lock
+++ b/Pipfile.lock
@@ -1,7 +1,7 @@
 {
     "_meta": {
         "hash": {
-            "sha256": "f46ce05dcdf97444899cc70317ce017d6c7d86c84f4a9595ac3eb338efa8f39d"
+            "sha256": "059d4b81d0ba16ad25b8fab4f35211b2a4d8ba1ac629f642a607e62a8f0c433a"
         },
         "pipfile-spec": 6,
         "requires": {
@@ -181,12 +181,34 @@
         }
     },
     "develop": {
+        "appdirs": {
+            "hashes": [
+                "sha256:7d5d0167b2b1ba821647616af46a749d1c653740dd0d2415100fe26e27afdf41",
+                "sha256:a841dacd6b99318a741b166adb07e19ee71a274450e68237b4650ca1055ab128"
+            ],
+            "version": "==1.4.4"
+        },
         "attrs": {
             "hashes": [
                 "sha256:149e90d6d8ac20db7a955ad60cf0e6881a3f20d37096140088356da6c716b0b1",
                 "sha256:ef6aaac3ca6cd92904cdd0d83f629a15f18053ec84e6432106f7a4d04ae4f5fb"
             ],
             "version": "==21.2.0"
+        },
+        "black": {
+            "hashes": [
+                "sha256:1c7aa6ada8ee864db745b22790a32f94b2795c253a75d6d9b5e439ff10d23116",
+                "sha256:c8373c6491de9362e39271630b65b964607bc5c79c83783547d76c839b3aa219"
+            ],
+            "index": "pypi",
+            "version": "==21.7b0"
+        },
+        "click": {
+            "hashes": [
+                "sha256:8c04c11192119b1ef78ea049e0a6f0463e4c48ef00a30160c704337586f3ad7a",
+                "sha256:fba402a4a47334742d782209a7c79bc448911afe1149d07bdabdf480b3e2f4b6"
+            ],
+            "version": "==8.0.1"
         },
         "iniconfig": {
             "hashes": [
@@ -195,12 +217,26 @@
             ],
             "version": "==1.1.1"
         },
+        "mypy-extensions": {
+            "hashes": [
+                "sha256:090fedd75945a69ae91ce1303b5824f428daf5a028d2f6ab8a299250a846f15d",
+                "sha256:2d82818f5bb3e369420cb3c4060a7970edba416647068eb4c5343488a6c604a8"
+            ],
+            "version": "==0.4.3"
+        },
         "packaging": {
             "hashes": [
                 "sha256:7dc96269f53a4ccec5c0670940a4281106dd0bb343f47b7471f779df49c2fbe7",
                 "sha256:c86254f9220d55e31cc94d69bade760f0847da8000def4dfe1c6b872fd14ff14"
             ],
             "version": "==21.0"
+        },
+        "pathspec": {
+            "hashes": [
+                "sha256:7d15c4ddb0b5c802d161efc417ec1a2558ea2653c2e8ad9c19098201dc1c993a",
+                "sha256:e564499435a2673d586f6b2130bb5b95f04a3ba06f81b8f895b651a3c76aabb1"
+            ],
+            "version": "==0.9.0"
         },
         "pluggy": {
             "hashes": [
@@ -239,12 +275,57 @@
             "index": "pypi",
             "version": "==3.6.1"
         },
+        "regex": {
+            "hashes": [
+                "sha256:026beb631097a4a3def7299aa5825e05e057de3c6d72b139c37813bfa351274b",
+                "sha256:14caacd1853e40103f59571f169704367e79fb78fac3d6d09ac84d9197cadd16",
+                "sha256:16d9eaa8c7e91537516c20da37db975f09ac2e7772a0694b245076c6d68f85da",
+                "sha256:18fdc51458abc0a974822333bd3a932d4e06ba2a3243e9a1da305668bd62ec6d",
+                "sha256:28e8af338240b6f39713a34e337c3813047896ace09d51593d6907c66c0708ba",
+                "sha256:3835de96524a7b6869a6c710b26c90e94558c31006e96ca3cf6af6751b27dca1",
+                "sha256:3905c86cc4ab6d71635d6419a6f8d972cab7c634539bba6053c47354fd04452c",
+                "sha256:3c09d88a07483231119f5017904db8f60ad67906efac3f1baa31b9b7f7cca281",
+                "sha256:4551728b767f35f86b8e5ec19a363df87450c7376d7419c3cac5b9ceb4bce576",
+                "sha256:459bbe342c5b2dec5c5223e7c363f291558bc27982ef39ffd6569e8c082bdc83",
+                "sha256:4f421e3cdd3a273bace013751c345f4ebeef08f05e8c10757533ada360b51a39",
+                "sha256:577737ec3d4c195c4aef01b757905779a9e9aee608fa1cf0aec16b5576c893d3",
+                "sha256:57fece29f7cc55d882fe282d9de52f2f522bb85290555b49394102f3621751ee",
+                "sha256:7976d410e42be9ae7458c1816a416218364e06e162b82e42f7060737e711d9ce",
+                "sha256:85f568892422a0e96235eb8ea6c5a41c8ccbf55576a2260c0160800dbd7c4f20",
+                "sha256:8764a78c5464ac6bde91a8c87dd718c27c1cabb7ed2b4beaf36d3e8e390567f9",
+                "sha256:8935937dad2c9b369c3d932b0edbc52a62647c2afb2fafc0c280f14a8bf56a6a",
+                "sha256:8fe58d9f6e3d1abf690174fd75800fda9bdc23d2a287e77758dc0e8567e38ce6",
+                "sha256:937b20955806381e08e54bd9d71f83276d1f883264808521b70b33d98e4dec5d",
+                "sha256:9569da9e78f0947b249370cb8fadf1015a193c359e7e442ac9ecc585d937f08d",
+                "sha256:a3b73390511edd2db2d34ff09aa0b2c08be974c71b4c0505b4a048d5dc128c2b",
+                "sha256:a4eddbe2a715b2dd3849afbdeacf1cc283160b24e09baf64fa5675f51940419d",
+                "sha256:a5c6dbe09aff091adfa8c7cfc1a0e83fdb8021ddb2c183512775a14f1435fe16",
+                "sha256:b63e3571b24a7959017573b6455e05b675050bbbea69408f35f3cb984ec54363",
+                "sha256:bb350eb1060591d8e89d6bac4713d41006cd4d479f5e11db334a48ff8999512f",
+                "sha256:bf6d987edd4a44dd2fa2723fca2790f9442ae4de2c8438e53fcb1befdf5d823a",
+                "sha256:bfa6a679410b394600eafd16336b2ce8de43e9b13f7fb9247d84ef5ad2b45e91",
+                "sha256:c856ec9b42e5af4fe2d8e75970fcc3a2c15925cbcc6e7a9bcb44583b10b95e80",
+                "sha256:cea56288eeda8b7511d507bbe7790d89ae7049daa5f51ae31a35ae3c05408531",
+                "sha256:ea212df6e5d3f60341aef46401d32fcfded85593af1d82b8b4a7a68cd67fdd6b",
+                "sha256:f35567470ee6dbfb946f069ed5f5615b40edcbb5f1e6e1d3d2b114468d505fc6",
+                "sha256:fbc20975eee093efa2071de80df7f972b7b35e560b213aafabcec7c0bd00bd8c",
+                "sha256:ff4a8ad9638b7ca52313d8732f37ecd5fd3c8e3aff10a8ccb93176fd5b3812f6"
+            ],
+            "version": "==2021.8.3"
+        },
         "toml": {
             "hashes": [
                 "sha256:806143ae5bfb6a3c6e736a764057db0e6a0e05e338b5630894a5f779cabb4f9b",
                 "sha256:b3bda1d108d5dd99f4a20d24d9c348e91c4db7ab1b749200bded2f839ccbe68f"
             ],
             "version": "==0.10.2"
+        },
+        "tomli": {
+            "hashes": [
+                "sha256:8dd0e9524d6f386271a36b41dbf6c57d8e32fd96fd22b6584679dc569d20899f",
+                "sha256:a5b75cb6f3968abb47af1b40c1819dc519ea82bcc065776a866e8d74c5ca9442"
+            ],
+            "version": "==1.2.1"
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -28,15 +28,11 @@ $ module load netcdf-bin
 $ module load cdo-bin
 ```
 
-Python installation should be done in a virtual environment. We recommend a Python3 virtual env, created and activated
-as follows:
+Python installation should be done in a virtual environment. We recommend `pipenv`:
 
 ```bash
-$ python3 -m venv venv
-$ source venv/bin/activate
-(venv) $ pip install -U pip setuptools wheel  # why are setuptools and wheel necessary?
-(venv) $ pip install -i https://pypi.pacificclimate.org/simple/ -r requirements.txt
-(venv) $ pip install .  # or pip install -e .
+$ pipenv install
+$ pipenv install --dev # to include development packages
 ```
 
 This installs the scripts described below.

--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ $ module load cdo-bin
 Python installation should be done in a virtual environment. We recommend `pipenv`:
 
 ```bash
-$ pipenv install
+$ pipenv install # Or
 $ pipenv install --dev # to include development packages
 ```
 

--- a/dp/argparse_helpers.py
+++ b/dp/argparse_helpers.py
@@ -4,7 +4,7 @@ Helpers for setting up argument parsing
 
 
 def strtobool(string):
-    return string.lower() in {'true', 't', 'yes', '1'}
+    return string.lower() in {"true", "t", "yes", "1"}
 
 
-log_level_choices = 'NOTSET DEBUG INFO WARNING ERROR CRITICAL'.split()
+log_level_choices = "NOTSET DEBUG INFO WARNING ERROR CRITICAL".split()

--- a/dp/decompose_flow_vectors.py
+++ b/dp/decompose_flow_vectors.py
@@ -126,7 +126,7 @@ def create_graticule_variables(axis, source, dest):
     """
     this function adds a netCDF graticule component variable(latitude/longitude)
     inside the destination file.
-    
+
     :param axis: (str) a griticule component to be created
     :param source: (netCDF4 Dataset) source netCDF Dataset
     :param dest_file: (str) path to destination netCDF file
@@ -141,7 +141,7 @@ def create_vector_variables(direction, dest, variable):
     """
     this function adds a netCDF direction vector component variable(eastward/nothward)
     inside the destination file.
-    
+
     :param direction: (str) a direction vector component to be created
     :param dest: (str) path to destination netCDF file
     :param variable: (str) netCDF variable describing flow direction
@@ -160,7 +160,7 @@ def create_vector_variables(direction, dest, variable):
 def generate_vector_component(dir_vec, source, dest, variable):
     """
     This function converts source file's VIC model vector values to
-    destination file's Two-Grid vector values. Basically, it splits 
+    destination file's Two-Grid vector values. Basically, it splits
     off a direction into x-y(eastward-northward) coordinates.
 
     :param dir_vec: (str) a direction vector component variable to be generated

--- a/dp/generate_climos.py
+++ b/dp/generate_climos.py
@@ -40,7 +40,7 @@ cdo = Cdo()
 
 
 def input_check(filepath, climo):
-    '''
+    """
     This function runs general checks on the given input arguments filepath and climo.
     There are 2 checking processes:
 
@@ -50,7 +50,7 @@ def input_check(filepath, climo):
 
     The function returns CFDataset and list.
     If any of the checks are not passed, the function returns None and empty list.
-    '''
+    """
     logger.info("")
     logger.info("Processing: {}".format(filepath))
 
@@ -63,31 +63,29 @@ def input_check(filepath, climo):
     periods = input_file.climo_periods.keys() & climo
     logger.info("climo_periods: {}".format(periods))
     if len(periods) == 0:
-        logger.critical(f"{input_file.filepath()} contains no standard climatological periods")
+        logger.critical(
+            f"{input_file.filepath()} contains no standard climatological periods"
+        )
         return None, []
 
     return input_file, periods
 
 
 def dry_run_handler(filepath, climo):
-    '''
+    """
     This function handles dry-run operation of generate_climos. The purpose of this function
-    is to check variables and attrbutes to be used for generate_climos. dry-run will not 
+    is to check variables and attrbutes to be used for generate_climos. dry-run will not
     produce any output files.
-    '''
+    """
     input_file, periods = input_check(filepath, climo)
 
-    for attr in ['project', 'institution', 'model', 'emissions', 'run']:
+    for attr in ["project", "institution", "model", "emissions", "run"]:
         try:
-            logger.info(
-                "{}: {}".format(attr, getattr(input_file.metadata, attr))
-            )
+            logger.info("{}: {}".format(attr, getattr(input_file.metadata, attr)))
         except Exception as e:
             logger.info("{}: {}: {}".format(attr, e.__class__.__name__, e))
-    logger.info(
-        "dependent_varnames: {}".format(input_file.dependent_varnames())
-    )
-    for attr in ['time_resolution', 'is_multi_year_mean']:
+    logger.info("dependent_varnames: {}".format(input_file.dependent_varnames()))
+    for attr in ["time_resolution", "is_multi_year_mean"]:
         logger.info("{}: {}".format(attr, getattr(input_file, attr)))
 
 
@@ -101,10 +99,10 @@ def generate_climos(
     split_intervals=True,
     resolutions={"yearly", "seasonal", "monthly"},
 ):
-    '''
+    """
     This function runs general generate_climos operation. The main purpose of this function
     is to call create_climo_files.
-    '''
+    """
     input_file, periods = input_check(filepath, climo)
 
     for period in periods:
@@ -618,7 +616,7 @@ def convert_longitude_range(climo_data):
 
 def convert_flux_var_units(input_file, climo_data):
     """If the file contains a 'pr' or 'prsn' variable, and if its units are per
-       second, convert its units to per day.
+    second, convert its units to per day.
     """
     flux_vars = [
         var for var in ["pr", "prsn"] if var in input_file.dependent_varnames()
@@ -738,7 +736,10 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
 
         # Update cell_methods to reflect the operation being done to the data
         validate_operation(operation)
-        cell_method_op = {"std": "standard_deviation", "mean": "mean",}[operation]
+        cell_method_op = {
+            "std": "standard_deviation",
+            "mean": "mean",
+        }[operation]
 
         for key in cf.variables.keys():
             try:
@@ -750,7 +751,10 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
                 continue
 
         # Update frequency attribute to reflect that this is a climo file.
-        suffix = {"std": "SD", "mean": "Mean",}[operation]
+        suffix = {
+            "std": "SD",
+            "mean": "Mean",
+        }[operation]
 
         prefix = "".join(
             abbr
@@ -782,7 +786,14 @@ def update_metadata_and_time_var(input_file, t_start, t_end, operation, climo_fi
         cf.time_var.climatology = "climatology_bnds"
         if "bnds" not in cf.dimensions:
             cf.createDimension("bnds", 2)
-        climo_bnds_var = cf.createVariable("climatology_bnds", "f4", ("time", "bnds",))
+        climo_bnds_var = cf.createVariable(
+            "climatology_bnds",
+            "f4",
+            (
+                "time",
+                "bnds",
+            ),
+        )
         climo_bnds_var.calendar = cf.time_var.calendar
         climo_bnds_var.units = cf.time_var.units
         climo_bnds_var[:] = date2num(
@@ -812,20 +823,20 @@ def update_generate_climos_history(args, netCDF_file, time_cdo_format, position=
 
     For example:
 
-    :history = 
+    :history =
         "Thu May 21 11:12:04 2020: cdo -O -seldate ..."    <--- position 0
         "Thu May 21 11:12:04: start: generate_climos ..."  <--- position 1: insert "start: genereate_climos"
         "Thu Mar 21 14:49:01 2019: cdo sellonlatbox ..."   <--- position 2
         "Thu Sep  1 14:34:03 2016: ncrcat ..."             <--- position 3
         "Thu Sep 01 14:33:15 2016: cdo -O seldate ..."     <--- position 4
-        
+
         ...
 
     or
 
-    :history = 
+    :history =
         "Thu May 21 11:12:05: end: generate_climos ..."    <--- position 0: insert "end: genereate_climos"
-        "Thu May 21 11:12:05 2020: cdo -O -replace ..."    <--- position 1 
+        "Thu May 21 11:12:05 2020: cdo -O -replace ..."    <--- position 1
         "Thu May 21 11:12:04 2020: cdo -O -timmean ..."    <--- position 2
         "Thu May 21 11:12:04 2020: cdo -O -seldate ..."    <--- position 3
         "Thu May 21 11:12:04: start: generate_climos ..."  <--- position 4

--- a/dp/generate_prsn.py
+++ b/dp/generate_prsn.py
@@ -20,85 +20,91 @@ logger = logging.getLogger(__name__)
 
 
 def dry_run(filepaths):
-    '''Perform metadata checks on the input files
+    """Perform metadata checks on the input files
 
-       Parameters:
-            filepaths (dict): Dictionary containing the three filepaths
-    '''
-    logger.info('Dry Run')
+    Parameters:
+         filepaths (dict): Dictionary containing the three filepaths
+    """
+    logger.info("Dry Run")
     for filepath in filepaths.values():
-        logger.info('')
-        logger.info(f'File: {filepath}')
+        logger.info("")
+        logger.info(f"File: {filepath}")
         try:
             dataset = CFDataset(filepath)
         except Exception as e:
-            logger.exception(f'{e.__class__.__name__}: {e}')
+            logger.exception(f"{e.__class__.__name__}: {e}")
 
-        for attr in 'project model institute experiment ensemble_member'.split():
+        for attr in "project model institute experiment ensemble_member".split():
             try:
-                logger.info(f'{attr}: {getattr(dataset.metadata, attr)}')
+                logger.info(f"{attr}: {getattr(dataset.metadata, attr)}")
             except Exception as e:
-                logger.info(f'{attr}: {e.__class__.__name__}: {e}')
-        logger.info(f'dependent_varnames: {dataset.dependent_varnames()}')
+                logger.info(f"{attr}: {e.__class__.__name__}: {e}")
+        logger.info(f"dependent_varnames: {dataset.dependent_varnames()}")
 
 
 def unique_shape(arrays):
-    '''Ensure each array in dict is the same shape'''
+    """Ensure each array in dict is the same shape"""
     shapes = {a.shape for a in arrays.values()}
     return len(shapes) == 1
 
 
 def is_unique_value(values):
-    '''Given a list ensure there is only one unique value'''
+    """Given a list ensure there is only one unique value"""
     return np.unique(values).size == 1
 
 
 def pr_freezing_from_units(unit):
-    '''Given a unit determine which temperature describes freezing'''
+    """Given a unit determine which temperature describes freezing"""
     freezing = Q_(0.0, ureg.degC)
 
     temp_unit = str(ureg.parse_units(unit))
-    if temp_unit != 'degC':
+    if temp_unit != "degC":
         freezing = freezing.to(temp_unit)
 
     return freezing.magnitude
 
 
-def create_prsn_netcdf_from_source(src, dst, to_delete=['original_name, comment']):
-    '''Using a precipiation netCDF as a template copy over the data applicable
-       to prsn
-    '''
+def create_prsn_netcdf_from_source(src, dst, to_delete=["original_name, comment"]):
+    """Using a precipiation netCDF as a template copy over the data applicable
+    to prsn
+    """
     # Create the dimensions of the file
     for name, dim in src.dimensions.items():
         dst.createDimension(name, len(dim) if not dim.isunlimited() else None)
 
     # Copy the globals
     unwanted_globals = [
-        'history',
+        "history",
     ]
-    dst.setncatts({attr:src.getncattr(attr)
-                   for attr in src.ncattrs() if attr not in unwanted_globals})
+    dst.setncatts(
+        {
+            attr: src.getncattr(attr)
+            for attr in src.ncattrs()
+            if attr not in unwanted_globals
+        }
+    )
 
     # Create the variables in the file
     for name, var in src.variables.items():
         dst.createVariable(name, var.dtype, var.dimensions)
 
         # Copy the variable attributes
-        dst.variables[name].setncatts({attr:var.getncattr(attr) for attr in var.ncattrs()})
+        dst.variables[name].setncatts(
+            {attr: var.getncattr(attr) for attr in var.ncattrs()}
+        )
 
         # we will be replacing pr data with prsn data
-        if name == 'pr':
+        if name == "pr":
             continue
-        logger.debug('Copying {}'.format(name))
+        logger.debug("Copying {}".format(name))
         dst.variables[name][:] = src.variables[name][:]
 
-
     # change pr metadata to prsn equivalents
-    dst.renameVariable('pr', 'prsn')
-    prsn_var = dst.variables['prsn']
+    dst.renameVariable("pr", "prsn")
+    prsn_var = dst.variables["prsn"]
 
-    prsn_var.standard_name = 'snowfall_flux'
-    prsn_var.long_name = 'Precipitation as Snow'
+    prsn_var.standard_name = "snowfall_flux"
+    prsn_var.long_name = "Precipitation as Snow"
 
     for item in set(to_delete):
         if hasattr(prsn_var, item):
@@ -106,7 +112,7 @@ def create_prsn_netcdf_from_source(src, dst, to_delete=['original_name, comment'
 
 
 def custom_filepath(directory, file):
-    '''Check if directory exists and return the filepath'''
+    """Check if directory exists and return the filepath"""
     if not os.path.exists(os.path.dirname(directory)):
         os.makedirs(os.path.dirname(directory))
 
@@ -114,165 +120,162 @@ def custom_filepath(directory, file):
 
 
 def create_filepath_from_source(source, new_var, outdir):
-    '''Using the source cmor_filename build a new output filepath with new_var
-       and output directory.
-    '''
-    variable, *rest = source.cmor_filename.split('_')
-    suffix = '_' + '_'.join(rest)
+    """Using the source cmor_filename build a new output filepath with new_var
+    and output directory.
+    """
+    variable, *rest = source.cmor_filename.split("_")
+    suffix = "_" + "_".join(rest)
     return custom_filepath(outdir, new_var + suffix)
 
 
 def has_required_vars(datasets, required_vars):
-    ''' Given a list of datasets and a list of required variables, ensure the
-        datasets contain all required variables.
-    '''
+    """Given a list of datasets and a list of required variables, ensure the
+    datasets contain all required variables.
+    """
     unique_vars = {var for dataset in datasets.values() for var in dataset.variables}
     required_vars = set(required_vars)
     return required_vars.intersection(unique_vars) == required_vars
 
 
 def matching_datasets(datasets):
-    '''Given a dict of datasets, match important metadata vars to ensure the
-       datasets are compatible.
-    '''
-    required_attrs = {
-        'project',
-        'model',
-        'institute',
-        'experiment',
-        'ensemble_member'
-    }
+    """Given a dict of datasets, match important metadata vars to ensure the
+    datasets are compatible.
+    """
+    required_attrs = {"project", "model", "institute", "experiment", "ensemble_member"}
     required = {
-       attr: [getattr(dataset.metadata, attr) for dataset in datasets.values()]
-          for attr in required_attrs
+        attr: [getattr(dataset.metadata, attr) for dataset in datasets.values()]
+        for attr in required_attrs
     }
 
     for attr, lst in required.items():
         if not is_unique_value(lst):
-            logger.warning('Metadata does not match for {}, {}'
-                           .format(attr, lst))
+            logger.warning("Metadata does not match for {}, {}".format(attr, lst))
             return False
     return True
 
 
 def convert_temperature_units(data, units_from, units_to):
-    '''Given an array of temperature values convert data to desired units'''
+    """Given an array of temperature values convert data to desired units"""
     units_from = ureg.parse_units(units_from)
     units_to = ureg.parse_units(units_to)
 
-    logger.debug('Converting temperature units from {}: to: {}'
-                 .format(units_from, units_to))
+    logger.debug(
+        "Converting temperature units from {}: to: {}".format(units_from, units_to)
+    )
     return (data * Q_(1.0, units_from)).to(units_to).magnitude
 
 
 def check_pr_units(pr_units):
-    '''Ensure we have expected pr units'''
+    """Ensure we have expected pr units"""
     valid_units = [
-        Unit('kg / m**2 / s'),
-        Unit('mm / s'),
-        Unit('kg / d / m**2'),
-        Unit('kg / m**2 / d')
+        Unit("kg / m**2 / s"),
+        Unit("mm / s"),
+        Unit("kg / d / m**2"),
+        Unit("kg / m**2 / d"),
     ]
     units = Unit.from_udunits_str(pr_units)
     return units in valid_units
 
 
 def preprocess_checks(datasets, variables, required_vars):
-    '''Perform all pre-processing checks and return a dict of failed checks (if any)'''
+    """Perform all pre-processing checks and return a dict of failed checks (if any)"""
     checks = {
-        'matching_datasets': matching_datasets(datasets),
-        'has_required_vars': has_required_vars(datasets, required_vars),
-        'check_pr_units': check_pr_units(variables['pr'].units),
-        'unique_shape': unique_shape(variables)
+        "matching_datasets": matching_datasets(datasets),
+        "has_required_vars": has_required_vars(datasets, required_vars),
+        "check_pr_units": check_pr_units(variables["pr"].units),
+        "unique_shape": unique_shape(variables),
     }
     return {check: result for check, result in checks.items() if not result}
 
 
 def process_to_prsn(variables, output_dataset, max_chunk_len):
-    '''Process precipitation data into snowfall data
+    """Process precipitation data into snowfall data
 
-       This method takes a precipitation, tasmin and tasmax file and uses them
-       to produce a snowfall file.  Using a mean of the temperature files the
-       script will look through all the cells in the datacube and 0 any cells
-       that are not freezing.  This mask applies to the precipiation file and
-       thus we are left with cells where it was cold enough for snow.
+    This method takes a precipitation, tasmin and tasmax file and uses them
+    to produce a snowfall file.  Using a mean of the temperature files the
+    script will look through all the cells in the datacube and 0 any cells
+    that are not freezing.  This mask applies to the precipiation file and
+    thus we are left with cells where it was cold enough for snow.
 
-       The input files are read in small chunks to avoid filling up all
-       available memory and crashing the script.  Size refers to the chunk size
-       being read in from the time dimension.  Example: Chunk read in
-       (100, all lon, all lat).
+    The input files are read in small chunks to avoid filling up all
+    available memory and crashing the script.  Size refers to the chunk size
+    being read in from the time dimension.  Example: Chunk read in
+    (100, all lon, all lat).
 
-       Parameters:
-            variables (dict): Dictionary containing three Variable objects
-                (pr, tasmin, tasmax)
-            output_dataset (CFDataset): Dataset for prsn output
-            max_chunk_len (int): Maximum length of a chunk
-    '''
-    tasmin_units = variables['tasmin'].units
-    tasmax_units = variables['tasmax'].units
-    matching_temp_units = is_unique_value([variables['tasmin'].units,
-                                           variables['tasmax'].units])
+    Parameters:
+         variables (dict): Dictionary containing three Variable objects
+             (pr, tasmin, tasmax)
+         output_dataset (CFDataset): Dataset for prsn output
+         max_chunk_len (int): Maximum length of a chunk
+    """
+    tasmin_units = variables["tasmin"].units
+    tasmax_units = variables["tasmax"].units
+    matching_temp_units = is_unique_value(
+        [variables["tasmin"].units, variables["tasmax"].units]
+    )
     freezing = pr_freezing_from_units(tasmin_units)
-    opt_chunk = opt_chunk_shape(variables['pr'].shape, max_chunk_len)
+    opt_chunk = opt_chunk_shape(variables["pr"].shape, max_chunk_len)
 
-    for chunk in chunk_slices(variables['pr'].shape, opt_chunk):
+    for chunk in chunk_slices(variables["pr"].shape, opt_chunk):
         if matching_temp_units:
             chunk_data = {varname: data[chunk] for varname, data in variables.items()}
         else:
             chunk_data = {
-                varname: convert_temperature_units(data[chunk], tasmin_units, tasmax_units)
-                if varname == 'tasmax' else data[chunk]
+                varname: convert_temperature_units(
+                    data[chunk], tasmin_units, tasmax_units
+                )
+                if varname == "tasmax"
+                else data[chunk]
                 for varname, data in variables.items()
             }
-        means = np.mean([chunk_data['tasmin'], chunk_data['tasmax']], axis=0)
-        prsn_data = np.where(means < freezing, chunk_data['pr'], 0)
-        output_dataset.variables['prsn'][chunk] = prsn_data
+        means = np.mean([chunk_data["tasmin"], chunk_data["tasmax"]], axis=0)
+        prsn_data = np.where(means < freezing, chunk_data["pr"], 0)
+        output_dataset.variables["prsn"][chunk] = prsn_data
 
 
 def generate_prsn_file(filepaths, chunk_size, outdir, output_file=None):
-    '''Generate precipiation as snow data using pr, tasmin and tasmax.
+    """Generate precipiation as snow data using pr, tasmin and tasmax.
 
-       Parameters:
-            filepaths (dict): Dictionary containin the three filepaths
-            chunk_size (int): Number of timeslices to be read/written
-            outdir (str): Output directory
-            output_file (str): Optional custom output filename
-    '''
+    Parameters:
+         filepaths (dict): Dictionary containin the three filepaths
+         chunk_size (int): Number of timeslices to be read/written
+         outdir (str): Output directory
+         output_file (str): Optional custom output filename
+    """
     for filepath in filepaths.values():
-        logger.info('Retrieving file: {}'.format(filepath))
+        logger.info("Retrieving file: {}".format(filepath))
 
-    datasets = {
-        varname: CFDataset(filepath)
-        for varname, filepath in filepaths.items()
-    }
+    datasets = {varname: CFDataset(filepath) for varname, filepath in filepaths.items()}
     variables = {
-        varname: datasets[varname].variables[varname]
-        for varname in filepaths.keys()
+        varname: datasets[varname].variables[varname] for varname in filepaths.keys()
     }
 
-    logger.info('Conducting pre-process checks')
+    logger.info("Conducting pre-process checks")
     required_vars = filepaths.keys()
     failures = preprocess_checks(datasets, variables, required_vars)
     if failures:
         for failure in failures.keys():
-            logger.exception('{} check failed'.format(failure))
-        raise Exception('Pre-process checks have failed')
+            logger.exception("{} check failed".format(failure))
+        raise Exception("Pre-process checks have failed")
 
-    logger.info('Creating outfile')
+    logger.info("Creating outfile")
     if output_file:
         output_filepath = custom_filepath(outdir, output_file)
     else:
-        output_filepath = create_filepath_from_source(datasets['pr'], 'prsn', outdir)
+        output_filepath = create_filepath_from_source(datasets["pr"], "prsn", outdir)
 
-    with CFDataset(output_filepath, mode='w') as output_dataset:
-        create_prsn_netcdf_from_source(datasets['pr'], output_dataset)
+    with CFDataset(output_filepath, mode="w") as output_dataset:
+        create_prsn_netcdf_from_source(datasets["pr"], output_dataset)
 
-    logger.info('Processing files')
-    spatial_dimensions = [dim.size for dimname, dim in datasets['pr'].dimensions.items()
-                          if dimname == 'lat' or dimname == 'lon']
+    logger.info("Processing files")
+    spatial_dimensions = [
+        dim.size
+        for dimname, dim in datasets["pr"].dimensions.items()
+        if dimname == "lat" or dimname == "lon"
+    ]
     max_chunk_len = chunk_size * np.prod(spatial_dimensions)
-    with CFDataset(output_filepath, mode='r+') as output_dataset:
+    with CFDataset(output_filepath, mode="r+") as output_dataset:
         process_to_prsn(variables, output_dataset, max_chunk_len)
 
-    logger.info('Output at: {}'.format(output_filepath))
-    logger.info('Complete')
+    logger.info("Output at: {}".format(output_filepath))
+    logger.info("Complete")

--- a/dp/split_merged_climos.py
+++ b/dp/split_merged_climos.py
@@ -8,7 +8,9 @@ from nchelpers import CFDataset
 
 
 # Set up logging
-formatter = logging.Formatter('%(asctime)s %(levelname)s: %(message)s', "%Y-%m-%d %H:%M:%S")
+formatter = logging.Formatter(
+    "%(asctime)s %(levelname)s: %(message)s", "%Y-%m-%d %H:%M:%S"
+)
 handler = logging.StreamHandler()
 handler.setFormatter(formatter)
 
@@ -24,27 +26,29 @@ def split_merged_climos(input_file, outdir):
 
     # Check that we can split this file
     if not input_file.is_multi_year_mean:
-        raise ValueError('File is not a multi-year mean')
+        raise ValueError("File is not a multi-year mean")
 
     output_filepaths = []
     start_timestep = 1
     for input_freqs, num_timesteps, output_freq in [
-        ({'msaClim'}, 12, 'mClim'),
-        ({'saClim', 'msaClim'}, 4, 'sClim'),
-        ({'saClim', 'msaClim'}, 1, 'aClim'),
+        ({"msaClim"}, 12, "mClim"),
+        ({"saClim", "msaClim"}, 4, "sClim"),
+        ({"saClim", "msaClim"}, 1, "aClim"),
     ]:
         if input_file.frequency in input_freqs:
             # The given climo interval set is in the file.
             logger.info("Splitting averaging interval '{}'".format(output_freq))
 
             # Determine what timesteps should be selected from the file
-            timesteps = list(range(start_timestep, start_timestep+num_timesteps))
+            timesteps = list(range(start_timestep, start_timestep + num_timesteps))
             start_timestep += num_timesteps
 
             # Split out those timesteps
-            temp_filepath = cdo.seltimestep(','.join(str(t) for t in timesteps), input=input_file.filepath())
+            temp_filepath = cdo.seltimestep(
+                ",".join(str(t) for t in timesteps), input=input_file.filepath()
+            )
 
-            with CFDataset(temp_filepath, mode='r+') as cf:
+            with CFDataset(temp_filepath, mode="r+") as cf:
                 # Update metadata in the split file
                 cf.frequency = output_freq
                 # Extract the final filename for this file
@@ -52,12 +56,16 @@ def split_merged_climos(input_file, outdir):
 
             # Move/copy split file to final location
             try:
-                logger.info('Output file: {}'.format(output_filepath))
+                logger.info("Output file: {}".format(output_filepath))
                 if not os.path.exists(os.path.dirname(output_filepath)):
                     os.makedirs(os.path.dirname(output_filepath))
                 shutil.move(temp_filepath, output_filepath)
             except Exception as e:
-                logger.warning('Failed to create output file. {}: {}'.format(e.__class__.__name__, e))
+                logger.warning(
+                    "Failed to create output file. {}: {}".format(
+                        e.__class__.__name__, e
+                    )
+                )
             else:
                 output_filepaths.append(output_filepath)
 

--- a/dp/units_helpers.py
+++ b/dp/units_helpers.py
@@ -15,53 +15,49 @@ import re
 from pint import UnitRegistry
 
 ureg = UnitRegistry()
-ureg.define('day = 24 * hour = d')  # add 'd' as a synonym for 'day'; udunits uses 'd'
+ureg.define("day = 24 * hour = d")  # add 'd' as a synonym for 'day'; udunits uses 'd'
 
 
 class Unit(ureg.Unit):
-
     @staticmethod
     def udunits_str_to_pint_parsable_str(udunits_str):
         """Convert any valid udunits string to a string that pint can parse."""
         # Convert powers
-        s = re.sub(r'(\^|\*\*)?(-?\d+)', r'**\2', udunits_str)
+        s = re.sub(r"(\^|\*\*)?(-?\d+)", r"**\2", udunits_str)
         # Convert multiplication operators
-        s = re.sub(r'(?<=[a-zA-Z0-9])\s*( |\.|-)\s*(?=[a-zA-Z])', r' * ', s)
+        s = re.sub(r"(?<=[a-zA-Z0-9])\s*( |\.|-)\s*(?=[a-zA-Z])", r" * ", s)
         return s
-
 
     @staticmethod
     def pint_str_to_udunits_str(pint_str):
         """Convert a pint str to a default formatted udunits string."""
         # Split `pint` string into parts separated by multiplication or division (* or /). Keep the separators.
-        pint_parts = re.split(r' ([\/\*]) ', pint_str)
+        pint_parts = re.split(r" ([\/\*]) ", pint_str)
 
         # Normalize the split so that it always begins with a * or /.
-        if pint_parts[0] == '1':
+        if pint_parts[0] == "1":
             pint_parts = pint_parts[1:]
         else:
-            pint_parts = ['*'] + pint_parts
+            pint_parts = ["*"] + pint_parts
 
         # Convert `pint` parts to `udunits` parts by extracting base units and powers and formatting them
         # in `udunits` default style.
         udunits_parts = []
         for i in range(0, len(pint_parts), 2):
-            sign = {'*': '', '/': '-'}[pint_parts[i]]
-            unit_power = re.split(r'\s*\*\*\s*', pint_parts[i+1])
-            if len(unit_power) == 1 and sign == '-':
-                unit_power.append('1')
+            sign = {"*": "", "/": "-"}[pint_parts[i]]
+            unit_power = re.split(r"\s*\*\*\s*", pint_parts[i + 1])
+            if len(unit_power) == 1 and sign == "-":
+                unit_power.append("1")
             udunits_parts.append(sign.join(unit_power))
 
-        return ' '.join(udunits_parts)
-
+        return " ".join(udunits_parts)
 
     @classmethod
     def from_udunits_str(cls, udunits_str):
         """Create a Unit object from a udunits formatted string."""
         return cls(cls.udunits_str_to_pint_parsable_str(udunits_str))
 
-
     def to_udunits_str(self):
         """Format self as a default `udunits` format string."""
         # Format self as a pint string with abbreviated units and convert it to a udunits string
-        return Unit.pint_str_to_udunits_str('{:~}'.format(self))
+        return Unit.pint_str_to_udunits_str("{:~}".format(self))

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,8 +1,0 @@
-python-dateutil
-cdo==1.5.3
-nchelpers==5.5.6
-pint
-PyYAML
-# for testing
-pytest
-pytest_mock

--- a/setup.py
+++ b/setup.py
@@ -40,8 +40,8 @@ setup(
         'Intended Audience :: Science/Research',
         'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
         'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering',
         'Topic :: Database',
         'Topic :: Software Development :: Libraries :: Python Modules'

--- a/setup.py
+++ b/setup.py
@@ -3,48 +3,42 @@ from setuptools import setup
 __version__ = (0, 8, 6)
 
 setup(
-    name='ce-dataprep',
-    description='PCIC Climate Explorer Data Preparation',
-    version='.'.join(str(d) for d in __version__),
-    author='Rod Glover',
-    author_email='rglover@uvic.ca',
-    url='https://github.com/pacificclimate/climate-explorer-data-prep',
-    keywords='science climate meteorology downscaling modelling climatology',
+    name="ce-dataprep",
+    description="PCIC Climate Explorer Data Preparation",
+    version=".".join(str(d) for d in __version__),
+    author="Rod Glover",
+    author_email="rglover@uvic.ca",
+    url="https://github.com/pacificclimate/climate-explorer-data-prep",
+    keywords="science climate meteorology downscaling modelling climatology",
     zip_safe=True,
-    install_requires='''
+    install_requires="""
         python-dateutil
         cdo
         nchelpers
         pint
         PyYAML
-    '''.split(),
-    packages=['dp'],
-    package_data = {
-        'dp': [
-            'data/*',
-            'tests/data/*.nc'
-        ]
-    },
+    """.split(),
+    packages=["dp"],
+    package_data={"dp": ["data/*", "tests/data/*.nc"]},
     include_package_data=True,
-    scripts='''
+    scripts="""
         scripts/generate_climos
         scripts/generate_prsn
         scripts/split_merged_climos
         scripts/update_metadata
         scripts/decompose_flow_vectors
-    '''.split(),
+    """.split(),
     classifiers=[
-        'Development Status :: 4 - Beta',
-        'Environment :: Console',
-        'Intended Audience :: Developers',
-        'Intended Audience :: Science/Research',
-        'License :: OSI Approved :: GNU General Public License v3 (GPLv3)',
-        'Operating System :: OS Independent',
-        'Programming Language :: Python :: 3.7',
-        'Programming Language :: Python :: 3.8',
-        'Topic :: Scientific/Engineering',
-        'Topic :: Database',
-        'Topic :: Software Development :: Libraries :: Python Modules'
-    ]
-
+        "Development Status :: 4 - Beta",
+        "Environment :: Console",
+        "Intended Audience :: Developers",
+        "Intended Audience :: Science/Research",
+        "License :: OSI Approved :: GNU General Public License v3 (GPLv3)",
+        "Operating System :: OS Independent",
+        "Programming Language :: Python :: 3.7",
+        "Programming Language :: Python :: 3.8",
+        "Topic :: Scientific/Engineering",
+        "Topic :: Database",
+        "Topic :: Software Development :: Libraries :: Python Modules",
+    ],
 )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -5,11 +5,11 @@ from nchelpers import CFDataset, standard_climo_periods
 
 # helpers
 def get_dataset(filename):
-    return CFDataset(resource_filename(__name__, 'data/tiny_{}.nc').format(filename))
+    return CFDataset(resource_filename(__name__, "data/tiny_{}.nc").format(filename))
 
 
 def get_filepath(file_key):
-    return resource_filename(__name__, 'data/tiny_{}.nc').format(file_key)
+    return resource_filename(__name__, "data/tiny_{}.nc").format(file_key)
 
 
 @fixture
@@ -22,53 +22,55 @@ def tiny_dataset(request):
     return CFDataset(get_filepath(request.param))
 
 
-@fixture(scope='function')
+@fixture(scope="function")
 def outdir(tmpdir_factory):
-    return str(tmpdir_factory.mktemp('outdir'))
+    return str(tmpdir_factory.mktemp("outdir"))
 
 
-@fixture(scope='function')
+@fixture(scope="function")
 def period(request):
     input_dataset = get_dataset(request.param)
-    if (len(input_dataset.climo_periods.keys()) > 0):
-        return list(input_dataset.climo_periods.keys() & standard_climo_periods().keys())[0]
+    if len(input_dataset.climo_periods.keys()) > 0:
+        return list(
+            input_dataset.climo_periods.keys() & standard_climo_periods().keys()
+        )[0]
     else:
         return ""
 
-@fixture(scope='function')
+
+@fixture(scope="function")
 def datasets():
     return {
-        'pr': get_dataset('daily_pr'),
-        'tasmin': get_dataset('daily_tasmin'),
-        'tasmax': get_dataset('daily_tasmax')
+        "pr": get_dataset("daily_pr"),
+        "tasmin": get_dataset("daily_tasmin"),
+        "tasmax": get_dataset("daily_tasmax"),
     }
 
 
 @fixture
 def fake_dataset(request, tmpdir_factory):
-    fn = tmpdir_factory.mktemp('testdata').join('test.nc')
-    with CFDataset(fn, mode='w') as dataset:
+    fn = tmpdir_factory.mktemp("testdata").join("test.nc")
+    with CFDataset(fn, mode="w") as dataset:
         try:
-            dataset.setncatts(request.param['attributes'])
+            dataset.setncatts(request.param["attributes"])
         except KeyError:
             pass
 
         try:
-            dimensions = request.param['dimensions']
+            dimensions = request.param["dimensions"]
         except KeyError:
             dimensions = []
         for dim_name, size in dimensions:
             dataset.createDimension(dim_name, size)
 
         try:
-            variables = request.param['variables']
+            variables = request.param["variables"]
         except KeyError:
             variables = []
         for spec in variables:
-            variable = dataset.createVariable(
-                spec['name'], 'f', spec['dimensions'])
+            variable = dataset.createVariable(spec["name"], "f", spec["dimensions"])
             try:
-                variable.setncatts(spec['attributes'])
+                variable.setncatts(spec["attributes"])
             except KeyError:
                 pass
 

--- a/tests/test_decompose_flow_vectors.py
+++ b/tests/test_decompose_flow_vectors.py
@@ -87,7 +87,13 @@ def test_missing_data():
 def assert_SystemExit_code(infile, outfile, variable, expected):
     with pytest.raises(subprocess.CalledProcessError) as e:
         subprocess.check_call(
-            ["python", "./scripts/decompose_flow_vectors", infile, outfile, variable,]
+            [
+                "python",
+                "./scripts/decompose_flow_vectors",
+                infile,
+                outfile,
+                variable,
+            ]
         )
     assert e.value.returncode == expected
 

--- a/tests/test_generate_climos.py
+++ b/tests/test_generate_climos.py
@@ -35,6 +35,7 @@ from dp.generate_climos import generate_climos, create_climo_files
 
 # Helper functions
 
+
 def t_start(year):
     """Returns the start date of a climatological processing period beginning at start of year"""
     return datetime(year, 1, 1)
@@ -49,33 +50,53 @@ def basename_components(filepath):
     """Returns the CMOR(ish) components of the basename (filename) of the given filepath."""
     # Slightly tricky because variable names can contain underscores, which separate components.
     # We find the location f of the frequency component in the split and use it to assemble the components properly.
-    pieces = os.path.basename(filepath).split('_')
+    pieces = os.path.basename(filepath).split("_")
     frequency_options = [
-        'msaClim', 'saClim', 'aClim', 'sClim', 'mClim',
-        'msaClimMean', 'saClimMean', 'aClimMean', 'sClimMean', 'mClimMean',
-        'msaClimSD', 'saClimSD', 'aClimSD', 'sClimSD', 'mClimSD'
+        "msaClim",
+        "saClim",
+        "aClim",
+        "sClim",
+        "mClim",
+        "msaClimMean",
+        "saClimMean",
+        "aClimMean",
+        "sClimMean",
+        "mClimMean",
+        "msaClimSD",
+        "saClimSD",
+        "aClimSD",
+        "sClimSD",
+        "mClimSD",
     ]
     f = next(i for i, piece in enumerate(pieces) if piece in frequency_options)
-    return ['_'.join(pieces[:f])] + pieces[f:]
+    return ["_".join(pieces[:f])] + pieces[f:]
+
 
 # Tests
 
-@mark.parametrize('tiny_filepath, operation', [
-    ('downscaled_tasmax', 'std'),
-    ('downscaled_pr', 'mean'),
-    ('gdd_seasonal', 'std'),
-    ('tr_annual', 'mean'),
-], indirect=['tiny_filepath'])
-@mark.parametrize('convert_longitudes, split_vars, split_intervals, resolutions',[
-        (True, True, True, "yearly"), 
+
+@mark.parametrize(
+    "tiny_filepath, operation",
+    [
+        ("downscaled_tasmax", "std"),
+        ("downscaled_pr", "mean"),
+        ("gdd_seasonal", "std"),
+        ("tr_annual", "mean"),
+    ],
+    indirect=["tiny_filepath"],
+)
+@mark.parametrize(
+    "convert_longitudes, split_vars, split_intervals, resolutions",
+    [
+        (True, True, True, "yearly"),
         (False, False, False, "seasonal"),
-    ]
+    ],
 )
 def test_create_climo_files_call(
-    mocker, 
-    outdir, 
-    tiny_filepath, 
-    operation, 
+    mocker,
+    outdir,
+    tiny_filepath,
+    operation,
     convert_longitudes,
     split_vars,
     split_intervals,
@@ -83,9 +104,9 @@ def test_create_climo_files_call(
 ):
     mock_ccf = mocker.patch("dp.generate_climos.create_climo_files")
     generate_climos(
-        tiny_filepath, 
-        outdir, 
-        operation, 
+        tiny_filepath,
+        outdir,
+        operation,
         convert_longitudes=convert_longitudes,
         split_vars=split_vars,
         split_intervals=split_intervals,
@@ -106,36 +127,75 @@ def test_create_climo_files_call(
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm','gcm', 'mean', t_start(1965), t_end(1970)),
-    ('gcm_360_day_cal', 'gcm_360_day_cal', 'std', t_start(1965), t_end(1970)),  # test date processing
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1971), t_end(2000)),  # test seasonal-only
-    ('tr_annual', 'tr_annual', 'mean', t_start(1961), t_end(1990)),  # test annual-only
-    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['tiny_dataset', 'period'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_existence(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "mean", t_start(1965), t_end(1970)),
+        (
+            "gcm_360_day_cal",
+            "gcm_360_day_cal",
+            "std",
+            t_start(1965),
+            t_end(1970),
+        ),  # test date processing
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        ("downscaled_pr", "downscaled_pr", "std", t_start(1961), t_end(1990)),
+        ("hydromodel_gcm", "hydromodel_gcm", "mean", t_start(1984), t_end(1995)),
+        (
+            "gdd_seasonal",
+            "gdd_seasonal",
+            "mean",
+            t_start(1971),
+            t_end(2000),
+        ),  # test seasonal-only
+        (
+            "tr_annual",
+            "tr_annual",
+            "mean",
+            t_start(1961),
+            t_end(1990),
+        ),  # test annual-only
+        ("daily_prsn", "daily_prsn", "mean", t_start(1950), t_end(2100)),
+    ],
+    indirect=["tiny_dataset", "period"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_existence(
+    period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals
+):
     """Test that the expected number of files was created and that the filenames returned by
     create_climo_files are those actually created.
     """
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=split_vars,
-                                     split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     num_vars = len(tiny_dataset.dependent_varnames())
     num_files = 1
-    num_intervals = {"daily": 3, "monthly": 3, "seasonal": 2, "yearly": 1}[tiny_dataset.time_resolution]
+    num_intervals = {"daily": 3, "monthly": 3, "seasonal": 2, "yearly": 1}[
+        tiny_dataset.time_resolution
+    ]
     if split_vars:
         num_files *= num_vars
     if split_intervals:
@@ -146,74 +206,118 @@ def test_existence(period, outdir, tiny_dataset, operation, t_start, t_end, spli
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm','gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1961), t_end(1990)),
-    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_filenames(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "std", t_start(1965), t_end(1970)),
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        ("downscaled_pr", "downscaled_pr", "std", t_start(1961), t_end(1990)),
+        ("hydromodel_gcm", "hydromodel_gcm", "mean", t_start(1984), t_end(1995)),
+        ("gdd_seasonal", "gdd_seasonal", "mean", t_start(1961), t_end(1990)),
+        ("daily_prsn", "daily_prsn", "mean", t_start(1950), t_end(2100)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_filenames(
+    period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals
+):
     """Test that the filenames are as expected. Tests only the following easy-to-test filename components:
     - variable name
     - frequency
     Testing all the components of the filenames would be a lot of work and would duplicate unit tests for
     the filename generator in nchelpers.
     """
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True, 
-                                     split_vars=split_vars,
-                                     split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     if split_vars:
         varnames = set(tiny_dataset.dependent_varnames())
     else:
-        varnames = {'+'.join(sorted(tiny_dataset.dependent_varnames()))}
+        varnames = {"+".join(sorted(tiny_dataset.dependent_varnames()))}
     assert varnames == set(basename_components(fp)[0] for fp in climo_files)
     for fp in climo_files:
         frequency = basename_components(fp)[1]
         with CFDataset(fp) as cf:
             assert cf.frequency == frequency
         if split_intervals:
-            assert frequency in 'mClim mClimSD mClimMean sClim sClimSD sClimMean aClim aClimSD aClimMean'.split()
+            assert (
+                frequency
+                in "mClim mClimSD mClimMean sClim sClimSD sClimMean aClim aClimSD aClimMean".split()
+            )
         else:
-            assert frequency in 'aClim aClimSD aClimMean saClim saClimSD saClimMean msaClim msaClimSD msaClimMean'.split()
+            assert (
+                frequency
+                in "aClim aClimSD aClimMean saClim saClimSD saClimMean msaClim msaClimSD msaClimMean".split()
+            )
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1981), t_end(2010)),
-    ('tr_annual', 'tr_annual', 'std', t_start(1960), t_end(1970)),
-    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100)),
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_climo_metadata(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "std", t_start(1965), t_end(1970)),
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        ("downscaled_pr", "downscaled_pr", "std", t_start(1961), t_end(1990)),
+        ("hydromodel_gcm", "hydromodel_gcm", "mean", t_start(1984), t_end(1995)),
+        ("gdd_seasonal", "gdd_seasonal", "mean", t_start(1981), t_end(2010)),
+        ("tr_annual", "tr_annual", "std", t_start(1960), t_end(1970)),
+        ("daily_prsn", "daily_prsn", "mean", t_start(1950), t_end(2100)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_climo_metadata(
+    period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals
+):
     """Test that the correct climo-specific metadata has been added/updated."""
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=split_vars, 
-                                     split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     frequencies = set()
 
     def history_items(hist_str):
@@ -226,56 +330,67 @@ def test_climo_metadata(period, outdir, tiny_dataset, operation, t_start, t_end,
             assert cf.is_multi_year
             # In Python2.7, datetime.datime.isoformat does not take params telling it how much precision to
             # provide in its output; standard requires 'seconds' precision, which means the first 19 characters.
-            assert cf.climo_start_time == t_start.isoformat()[:19] + 'Z'
-            assert cf.climo_end_time == t_end.isoformat()[:19] + 'Z'
-            assert getattr(cf, 'climo_tracking_id', None) == getattr(tiny_dataset, 'tracking_id', None)
+            assert cf.climo_start_time == t_start.isoformat()[:19] + "Z"
+            assert cf.climo_end_time == t_end.isoformat()[:19] + "Z"
+            assert getattr(cf, "climo_tracking_id", None) == getattr(
+                tiny_dataset, "tracking_id", None
+            )
 
             # Tests for history metadata updates
             assert cf.history
             hist_lines = cf.history.split("\n")
             end_items = history_items(hist_lines[0])
-            assert end_items[-1].split(" ")[0] == "generate_climos" and end_items[-2] == "end"
+            assert (
+                end_items[-1].split(" ")[0] == "generate_climos"
+                and end_items[-2] == "end"
+            )
             found_start = False
             for idx, h in enumerate(hist_lines):
                 h_items = history_items(h)
-                if h_items[-2] == "start" and h_items[-1].split(" ")[0] == "generate_climos":
+                if (
+                    h_items[-2] == "start"
+                    and h_items[-1].split(" ")[0] == "generate_climos"
+                ):
                     found_start = True
                     break
             assert found_start
-            original_hist = hist_lines[idx+1:]
+            original_hist = hist_lines[idx + 1 :]
             assert "\n".join(original_hist) == tiny_dataset.history
 
     suffix = {
-        'std': 'SD',
-        'mean': 'Mean',
+        "std": "SD",
+        "mean": "Mean",
     }[operation]
 
     if split_intervals:
         assert frequencies == {
-           'daily': {'mClim' + suffix, 'sClim' + suffix, 'aClim' + suffix},
-           'monthly': {'mClim' + suffix, 'sClim' + suffix, 'aClim' + suffix},
-           'seasonal': {'sClim' + suffix, 'aClim' + suffix},
-           'yearly': {'aClim' + suffix},
+            "daily": {"mClim" + suffix, "sClim" + suffix, "aClim" + suffix},
+            "monthly": {"mClim" + suffix, "sClim" + suffix, "aClim" + suffix},
+            "seasonal": {"sClim" + suffix, "aClim" + suffix},
+            "yearly": {"aClim" + suffix},
         }[tiny_dataset.time_resolution]
     else:
         assert frequencies == {
-            'daily': {'msaClim' + suffix},
-            'monthly': {'msaClim' + suffix},
-            'seasonal': {'saClim' + suffix},
-            'yearly': {'aClim' + suffix}
+            "daily": {"msaClim" + suffix},
+            "monthly": {"msaClim" + suffix},
+            "seasonal": {"saClim" + suffix},
+            "yearly": {"aClim" + suffix},
         }[tiny_dataset.time_resolution]
 
 
-@mark.parametrize('period, tiny_dataset, comparison', [
-    ('gdd_seasonal', 'gdd_seasonal', 'greatermean'),
-    ('fd_monthly', 'fd_monthly', 'greatermean'),
-    ('txx_monthly', 'txx_monthly', 'greatermin'),
-    ('tnn_monthly', 'tnn_monthly', 'lessermax')
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('t_start, t_end', [
-    (t_start(1971), t_end(2000)),
-    (t_start(2010), t_end(2039))
-    ])
+@mark.parametrize(
+    "period, tiny_dataset, comparison",
+    [
+        ("gdd_seasonal", "gdd_seasonal", "greatermean"),
+        ("fd_monthly", "fd_monthly", "greatermean"),
+        ("txx_monthly", "txx_monthly", "greatermin"),
+        ("tnn_monthly", "tnn_monthly", "lessermax"),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "t_start, t_end", [(t_start(1971), t_end(2000)), (t_start(2010), t_end(2039))]
+)
 def test_variable_aggregation(period, outdir, tiny_dataset, comparison, t_start, t_end):
     """Test that the values for variables aggregated within a year are
     in the expected range. For these variables, the value of a year is
@@ -294,112 +409,205 @@ def test_variable_aggregation(period, outdir, tiny_dataset, comparison, t_start,
      - Minimum variables should have smaller maximums and means but similar
        minimums."""
     test = {
-        "greatermean": lambda a, b : a.mean() > b.mean(),
+        "greatermean": lambda a, b: a.mean() > b.mean(),
         "greatermin": lambda a, b: a.min() > b.min(),
-        "lessermax": lambda a, b: a.max() < b.max()
-        }[comparison]
-    climo_files = create_climo_files(period, outdir, tiny_dataset, "mean",
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=False, split_intervals=True,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+        "lessermax": lambda a, b: a.max() < b.max(),
+    }[comparison]
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        "mean",
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=False,
+        split_intervals=True,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     for cf in climo_files:
         for var in tiny_dataset.dependent_varnames():
             invar = tiny_dataset.variables[var][:]
             with CFDataset(cf) as out:
                 outvar = out.variables[var][:]
-                timeres_ordinality = {"daily": 1,
-                                      "monthly": 2,
-                                      "seasonal": 3,
-                                      "yearly": 4}
+                timeres_ordinality = {
+                    "daily": 1,
+                    "monthly": 2,
+                    "seasonal": 3,
+                    "yearly": 4,
+                }
                 inres = timeres_ordinality[tiny_dataset.time_resolution]
                 outres = timeres_ordinality[out.time_resolution]
                 if outres > inres:
                     assert test(outvar, invar)
 
 
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('wsdi_annual', 'wsdi_annual', 'mean', t_start(2010), t_end(2039)),
-    ('wsdi_annual', 'wsdi_annual', 'std', t_start(1961), t_end(1990))
-    ], indirect=['period', 'tiny_dataset'])
-def test_duration_variable_resolutions(period, outdir, tiny_dataset, operation, t_start, t_end):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("wsdi_annual", "wsdi_annual", "mean", t_start(2010), t_end(2039)),
+        ("wsdi_annual", "wsdi_annual", "std", t_start(1961), t_end(1990)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+def test_duration_variable_resolutions(
+    period, outdir, tiny_dataset, operation, t_start, t_end
+):
     """Datasets with duration variables (values measuring the number of
     consecutive days something happens) cannot be aggregated into coarser
     time values. Test that output resolution matches input resolution."""
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=False, split_intervals=False,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=False,
+        split_intervals=False,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     for cf in climo_files:
         with CFDataset(cf) as output:
             assert tiny_dataset.time_resolution == output.time_resolution
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end, var', [
-    ('downscaled_pr', 'downscaled_pr', 'mean', t_start(1965), t_end(1970), 'pr'),
-    ('downscaled_pr_packed', 'downscaled_pr_packed', 'std', t_start(1965), t_end(1970), 'pr'),
-    ('daily_prsn', 'daily_prsn', 'mean', t_start(1950), t_end(2100), 'prsn'),
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_pr_units_conversion(period, outdir, tiny_dataset, operation, t_start, t_end, var, split_vars, split_intervals):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end, var",
+    [
+        ("downscaled_pr", "downscaled_pr", "mean", t_start(1965), t_end(1970), "pr"),
+        (
+            "downscaled_pr_packed",
+            "downscaled_pr_packed",
+            "std",
+            t_start(1965),
+            t_end(1970),
+            "pr",
+        ),
+        ("daily_prsn", "daily_prsn", "mean", t_start(1950), t_end(2100), "prsn"),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_pr_units_conversion(
+    period,
+    outdir,
+    tiny_dataset,
+    operation,
+    t_start,
+    t_end,
+    var,
+    split_vars,
+    split_intervals,
+):
     """Test that units conversion for 'pr' variable is performed properly, for both packed and unpacked files.
     Test for unpacked file is pretty elementary: check pr units.
     Test for packed checks that packing params are modified correctly.
     """
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=split_vars, split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
 
     assert var in tiny_dataset.dependent_varnames()
     input_pr_var = tiny_dataset.variables[var]
-    assert Unit.from_udunits_str(input_pr_var.units) in [Unit('kg/m**2/s'), Unit('mm/s')]
+    assert Unit.from_udunits_str(input_pr_var.units) in [
+        Unit("kg/m**2/s"),
+        Unit("mm/s"),
+    ]
     seconds_per_day = 86400
     for fp in climo_files:
         with CFDataset(fp) as cf:
             if var in cf.dependent_varnames():
                 output_pr_var = cf.variables[var]
-                assert Unit.from_udunits_str(output_pr_var.units) in [Unit('kg/m**2/day'), Unit('mm/day')]
-                if hasattr(input_pr_var, 'scale_factor') or hasattr(input_pr_var, 'add_offset'):
+                assert Unit.from_udunits_str(output_pr_var.units) in [
+                    Unit("kg/m**2/day"),
+                    Unit("mm/day"),
+                ]
+                if hasattr(input_pr_var, "scale_factor") or hasattr(
+                    input_pr_var, "add_offset"
+                ):
                     try:
-                        assert output_pr_var.scale_factor == seconds_per_day * input_pr_var.scale_factor
+                        assert (
+                            output_pr_var.scale_factor
+                            == seconds_per_day * input_pr_var.scale_factor
+                        )
                     except AttributeError:
                         assert output_pr_var.scale_factor == seconds_per_day * 1.0
                     try:
-                        assert output_pr_var.add_offset == seconds_per_day * input_pr_var.add_offset
+                        assert (
+                            output_pr_var.add_offset
+                            == seconds_per_day * input_pr_var.add_offset
+                        )
                     except AttributeError:
                         assert output_pr_var.add_offset == 0.0
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    ('downscaled_pr', 'downscaled_pr', 'std', t_start(1961), t_end(1990)),
-    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-    ('gdd_seasonal', 'gdd_seasonal', 'mean', t_start(1971), t_end(2000))
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_dependent_variables(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "std", t_start(1965), t_end(1970)),
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        ("downscaled_pr", "downscaled_pr", "std", t_start(1961), t_end(1990)),
+        ("hydromodel_gcm", "hydromodel_gcm", "mean", t_start(1984), t_end(1995)),
+        ("gdd_seasonal", "gdd_seasonal", "mean", t_start(1971), t_end(2000)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_dependent_variables(
+    period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals
+):
     """Test that the output files contain the expected dependent variables"""
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=split_vars, split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     dependent_varnames_in_cfs = set()
     for fp in climo_files:
         with CFDataset(fp) as cf:
@@ -412,49 +620,69 @@ def test_dependent_variables(period, outdir, tiny_dataset, operation, t_start, t
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'gcm', 'mean', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    # No need to repleat with downscaled_pr
-    ('hydromodel_gcm', 'hydromodel_gcm', 'mean', t_start(1984), t_end(1995)),
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-def test_time_and_climo_bounds_vars(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals):
-    """Test that the climo output files contain the expected time values and climo bounds. """
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation,
-                                     t_start, t_end, convert_longitudes=True,
-                                     split_vars=split_vars, split_intervals=split_intervals,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "mean", t_start(1965), t_end(1970)),
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        # No need to repleat with downscaled_pr
+        ("hydromodel_gcm", "hydromodel_gcm", "mean", t_start(1984), t_end(1995)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+def test_time_and_climo_bounds_vars(
+    period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals
+):
+    """Test that the climo output files contain the expected time values and climo bounds."""
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        convert_longitudes=True,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
 
     for fp in climo_files:
         with CFDataset(fp) as cf:
             expected_num_time_values = {
-                'mClim': 12,
-                'sClim': 4,
-                'aClim': 1,
-                'saClim': 5,
-                'msaClim': 17,
-                'mClimMean': 12,
-                'sClimMean': 4,
-                'aClimMean': 1,
-                'saClimMean': 5,
-                'msaClimMean': 17,
-                'mClimSD': 12,
-                'sClimSD': 4,
-                'aClimSD': 1,
-                'saClimSD': 5,
-                'msaClimSD': 17,
+                "mClim": 12,
+                "sClim": 4,
+                "aClim": 1,
+                "saClim": 5,
+                "msaClim": 17,
+                "mClimMean": 12,
+                "sClimMean": 4,
+                "aClimMean": 1,
+                "saClimMean": 5,
+                "msaClimMean": 17,
+                "mClimSD": 12,
+                "sClimSD": 4,
+                "aClimSD": 1,
+                "saClimSD": 5,
+                "msaClimSD": 17,
             }[cf.frequency]
 
             assert cf.time_var
-            assert cf.time_var.climatology == 'climatology_bnds'
+            assert cf.time_var.climatology == "climatology_bnds"
             climo_bnds_var = cf.variables[cf.time_var.climatology]
             assert climo_bnds_var
 
@@ -462,121 +690,189 @@ def test_time_and_climo_bounds_vars(period, outdir, tiny_dataset, operation, t_s
             assert len(climo_bnds_var) == expected_num_time_values
 
             climo_year = (t_start.year + t_end.year + 1) / 2
-            time_steps = (t for t in cf.time_steps['datetime'])
+            time_steps = (t for t in cf.time_steps["datetime"])
             climo_bnds = (cb for cb in climo_bnds_var)
 
             def d2n(date):
                 return date2num(date, cf.time_var.units, cf.time_var.calendar)
 
             # Test monthly timesteps and climo bounds
-            if cf.frequency in {'mClim', 'msaClim', 'mClimSD', 'msaClimSD'}:
+            if cf.frequency in {"mClim", "msaClim", "mClimSD", "msaClimSD"}:
                 for month in range(1, 13):
                     t = next(time_steps)
                     assert (t.year, t.month, t.day) == (climo_year, month, 15)
                     cb = next(climo_bnds)
                     assert len(cb) == 2
                     assert cb[0] == d2n(datetime(t_start.year, month, 1))
-                    assert cb[1] == d2n(datetime(t_end.year, month, 1) + relativedelta(months=1))
+                    assert cb[1] == d2n(
+                        datetime(t_end.year, month, 1) + relativedelta(months=1)
+                    )
 
             # Test seasonal timesteps and climo bounds
-            if cf.frequency in {'sClim', 'msaClim', 'sClimSD', 'msaClimSD'}:
+            if cf.frequency in {"sClim", "msaClim", "sClimSD", "msaClimSD"}:
                 for month in [1, 4, 7, 10]:  # center months of seasons
                     t = next(time_steps)
                     assert (t.year, t.month, t.day) == (climo_year, month, 16)
                     cb = next(climo_bnds)
-                    assert cb[0] == d2n(datetime(t_start.year, month, 1) + relativedelta(months=-1))
-                    assert cb[1] == d2n(datetime(t_end.year, month, 1) + relativedelta(months=2))
+                    assert cb[0] == d2n(
+                        datetime(t_start.year, month, 1) + relativedelta(months=-1)
+                    )
+                    assert cb[1] == d2n(
+                        datetime(t_end.year, month, 1) + relativedelta(months=2)
+                    )
 
             # Test annual timestep and climo bounds
-            if cf.frequency in {'aClimSD', 'msaClimSD'}:
+            if cf.frequency in {"aClimSD", "msaClimSD"}:
                 t = next(time_steps)
                 assert (t.year, t.month, t.day) == (climo_year, 7, 2)
                 cb = next(climo_bnds)
                 assert cb[0] == d2n(t_start)
-                assert cb[1] == d2n(datetime(t_end.year+1, 1, 1))
+                assert cb[1] == d2n(datetime(t_end.year + 1, 1, 1))
 
 
 @mark.slow
-@mark.parametrize('period, tiny_dataset, operation, t_start, t_end', [
-    ('gcm', 'gcm', 'std', t_start(1965), t_end(1970)),
-    ('downscaled_tasmax', 'downscaled_tasmax', 'mean', t_start(1961), t_end(1990)),
-    # No need to repleat with downscaled_pr
-    ('hydromodel_gcm', 'hydromodel_gcm', 'std', t_start(1984), t_end(1995)),
-], indirect=['period', 'tiny_dataset'])
-@mark.parametrize('split_vars', [
-    False,
-    True,
-])
-@mark.parametrize('split_intervals', [
-    False,
-    True,
-])
-@mark.parametrize('convert_longitudes', [
-    False,
-    True,
-])
-def test_convert_longitudes(period, outdir, tiny_dataset, operation, t_start, t_end, split_vars, split_intervals, convert_longitudes):
+@mark.parametrize(
+    "period, tiny_dataset, operation, t_start, t_end",
+    [
+        ("gcm", "gcm", "std", t_start(1965), t_end(1970)),
+        ("downscaled_tasmax", "downscaled_tasmax", "mean", t_start(1961), t_end(1990)),
+        # No need to repleat with downscaled_pr
+        ("hydromodel_gcm", "hydromodel_gcm", "std", t_start(1984), t_end(1995)),
+    ],
+    indirect=["period", "tiny_dataset"],
+)
+@mark.parametrize(
+    "split_vars",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "split_intervals",
+    [
+        False,
+        True,
+    ],
+)
+@mark.parametrize(
+    "convert_longitudes",
+    [
+        False,
+        True,
+    ],
+)
+def test_convert_longitudes(
+    period,
+    outdir,
+    tiny_dataset,
+    operation,
+    t_start,
+    t_end,
+    split_vars,
+    split_intervals,
+    convert_longitudes,
+):
     """Test that longitude conversion is performed correctly."""
-    climo_files = create_climo_files(period, outdir, tiny_dataset, operation, t_start, t_end,
-                                     split_vars=split_vars, split_intervals=split_intervals,
-                                     convert_longitudes=convert_longitudes,
-                                     output_resolutions={"yearly", "seasonal", "monthly"})
+    climo_files = create_climo_files(
+        period,
+        outdir,
+        tiny_dataset,
+        operation,
+        t_start,
+        t_end,
+        split_vars=split_vars,
+        split_intervals=split_intervals,
+        convert_longitudes=convert_longitudes,
+        output_resolutions={"yearly", "seasonal", "monthly"},
+    )
     input_lon_var = tiny_dataset.lon_var[:]
     for fp in climo_files:
         with CFDataset(fp) as output_file:
             output_lon_var = output_file.lon_var[:]
             check_these = [(input_lon_var, output_lon_var)]
-            if hasattr(input_lon_var, 'bounds'):
-                check_these.append((tiny_dataset.variables[input_lon_var.bounds],
-                                    output_file.variables[output_lon_var.bounds]))
+            if hasattr(input_lon_var, "bounds"):
+                check_these.append(
+                    (
+                        tiny_dataset.variables[input_lon_var.bounds],
+                        output_file.variables[output_lon_var.bounds],
+                    )
+                )
             for input_lon_var, output_lon_var in check_these:
                 if convert_longitudes:
-                    assert all(-180 <= lon < 180 for _, lon in enumerate(output_lon_var))
-                    assert all(output_lon_var[i] == input_lon if input_lon < 180 else input_lon - 360
-                               for i, input_lon in enumerate(input_lon_var))
+                    assert all(
+                        -180 <= lon < 180 for _, lon in enumerate(output_lon_var)
+                    )
+                    assert all(
+                        output_lon_var[i] == input_lon
+                        if input_lon < 180
+                        else input_lon - 360
+                        for i, input_lon in enumerate(input_lon_var)
+                    )
                 else:
-                    assert all(-180 <= lon < 360 for _, lon in enumerate(output_lon_var))
-                    assert all(output_lon_var[i] == input_lon for i, input_lon in enumerate(input_lon_var))
+                    assert all(
+                        -180 <= lon < 360 for _, lon in enumerate(output_lon_var)
+                    )
+                    assert all(
+                        output_lon_var[i] == input_lon
+                        for i, input_lon in enumerate(input_lon_var)
+                    )
 
 
-@mark.parametrize(('resolutions'), [
-    {'yearly'},
-    {'yearly', 'seasonal'},
-    {'yearly', 'seasonal', 'monthly'},
-    {'monthly', 'daily'}, # Daily does not exist
-    set()
-])
-@mark.parametrize(('split_intervals'), [
-    True,
-    False
-])
+@mark.parametrize(
+    ("resolutions"),
+    [
+        {"yearly"},
+        {"yearly", "seasonal"},
+        {"yearly", "seasonal", "monthly"},
+        {"monthly", "daily"},  # Daily does not exist
+        set(),
+    ],
+)
+@mark.parametrize(("split_intervals"), [True, False])
 def test_resolution_filter(outdir, datasets, resolutions, split_intervals):
-    tiny_dataset = datasets['tasmax']
+    tiny_dataset = datasets["tasmax"]
     climo_files = create_climo_files(
-        "", outdir, tiny_dataset, 'mean', t_start(1965), t_end(1970),
-        split_vars=False, split_intervals=split_intervals,
-        convert_longitudes=False, output_resolutions=resolutions
+        "",
+        outdir,
+        tiny_dataset,
+        "mean",
+        t_start(1965),
+        t_end(1970),
+        split_vars=False,
+        split_intervals=split_intervals,
+        convert_longitudes=False,
+        output_resolutions=resolutions,
     )
     # Only these resolutions are supported as aggregation targets
     if split_intervals:
-        resolutions = resolutions.intersection({'yearly', 'seasonal', 'monthly'})
+        resolutions = resolutions.intersection({"yearly", "seasonal", "monthly"})
         assert len(climo_files) == len(resolutions)
     else:
         assert len(climo_files) == min(1, len(resolutions))
 
 
-@mark.parametrize(('period, tiny_dataset'), [
-    ('tr_annual','tr_annual')
-], indirect=['period', 'tiny_dataset'])
+@mark.parametrize(
+    ("period, tiny_dataset"),
+    [("tr_annual", "tr_annual")],
+    indirect=["period", "tiny_dataset"],
+)
 def test_resolution_warning(period, outdir, tiny_dataset):
-    '''If we try to compute a monthly climo from an annual file
-       there should be zero output files and a warning issued
-    '''
+    """If we try to compute a monthly climo from an annual file
+    there should be zero output files and a warning issued
+    """
     with warns(Warning) as record:
         climo_files = create_climo_files(
-            period, outdir, tiny_dataset, 'mean', t_start(1965),
-            t_end(1971), split_vars=True, split_intervals=True,
-            convert_longitudes=True, output_resolutions={'monthly'}
+            period,
+            outdir,
+            tiny_dataset,
+            "mean",
+            t_start(1965),
+            t_end(1971),
+            split_vars=True,
+            split_intervals=True,
+            convert_longitudes=True,
+            output_resolutions={"monthly"},
         )
 
     def contains_warning(record):

--- a/tests/test_generate_prsn.py
+++ b/tests/test_generate_prsn.py
@@ -7,89 +7,134 @@ from pkg_resources import resource_filename
 
 from nchelpers import CFDataset
 from conftest import get_dataset
-from dp.generate_prsn import unique_shape, is_unique_value, \
-    pr_freezing_from_units, create_prsn_netcdf_from_source, \
-    create_filepath_from_source, has_required_vars, matching_datasets, \
-    check_pr_units, process_to_prsn, convert_temperature_units
+from dp.generate_prsn import (
+    unique_shape,
+    is_unique_value,
+    pr_freezing_from_units,
+    create_prsn_netcdf_from_source,
+    create_filepath_from_source,
+    has_required_vars,
+    matching_datasets,
+    check_pr_units,
+    process_to_prsn,
+    convert_temperature_units,
+)
 
 
-@pytest.mark.parametrize('arrays', [
-    ({'shape1': np.arange(10).reshape(2, 5), 'shape2': np.arange(10).reshape(2, 5)}),
-    ({'shape1': np.arange(100).reshape(2, 5, 10), 'shape2': np.arange(100).reshape(2, 5, 10)})
-])
+@pytest.mark.parametrize(
+    "arrays",
+    [
+        (
+            {
+                "shape1": np.arange(10).reshape(2, 5),
+                "shape2": np.arange(10).reshape(2, 5),
+            }
+        ),
+        (
+            {
+                "shape1": np.arange(100).reshape(2, 5, 10),
+                "shape2": np.arange(100).reshape(2, 5, 10),
+            }
+        ),
+    ],
+)
 def test_unique_shape(arrays):
     assert unique_shape(arrays)
 
 
-@pytest.mark.parametrize('arrays', [
-    ({'shape1': np.arange(10).reshape(2, 5), 'shape2': np.arange(10).reshape(10, 1)}),
-    ({'shape1': np.arange(100).reshape(2, 5, 10), 'shape2': np.arange(100).reshape(10, 10)})
-])
+@pytest.mark.parametrize(
+    "arrays",
+    [
+        (
+            {
+                "shape1": np.arange(10).reshape(2, 5),
+                "shape2": np.arange(10).reshape(10, 1),
+            }
+        ),
+        (
+            {
+                "shape1": np.arange(100).reshape(2, 5, 10),
+                "shape2": np.arange(100).reshape(10, 10),
+            }
+        ),
+    ],
+)
 def test_unique_shape_different_shape(arrays):
     assert not unique_shape(arrays)
 
 
-@pytest.mark.parametrize('values', [
-    ([1, 1, 1]),
-    ([True, True, True]),
-    (['a', 'a', 'a'])
-])
+@pytest.mark.parametrize(
+    "values", [([1, 1, 1]), ([True, True, True]), (["a", "a", "a"])]
+)
 def test_is_unique_value(values):
     assert is_unique_value(values)
 
 
-@pytest.mark.parametrize('values', [
-    ([1, 1, 'not_matching']),
-    ([True, True, 'not_matching']),
-    (['a', 'a', 'not_matching'])
-])
+@pytest.mark.parametrize(
+    "values",
+    [
+        ([1, 1, "not_matching"]),
+        ([True, True, "not_matching"]),
+        (["a", "a", "not_matching"]),
+    ],
+)
 def test_is_unique_value_not_unique(values):
     assert not is_unique_value(values)
 
 
-@pytest.mark.parametrize('unit, expected', [
-    ('degC', 0.0),
-    ('K', 273.15)
-])
+@pytest.mark.parametrize("unit, expected", [("degC", 0.0), ("K", 273.15)])
 def test_pr_freezing_from_units(unit, expected):
     assert pr_freezing_from_units(unit) == expected
 
 
-@pytest.mark.parametrize('tiny_dataset', [
-    ('downscaled_pr')
-], indirect=['tiny_dataset'])
-@pytest.mark.parametrize('fake_dataset', [
-    {}  # empty fake dataset
-], indirect=['fake_dataset'])
+@pytest.mark.parametrize("tiny_dataset", [("downscaled_pr")], indirect=["tiny_dataset"])
+@pytest.mark.parametrize(
+    "fake_dataset", [{}], indirect=["fake_dataset"]  # empty fake dataset
+)
 def test_create_prsn_netcdf_from_source(tiny_dataset, fake_dataset):
     create_prsn_netcdf_from_source(tiny_dataset, fake_dataset)
-    assert fake_dataset.dependent_varnames() == ['prsn']
-    assert np.shape(fake_dataset.variables['prsn']) == (11688, 4, 2)
-    assert fake_dataset.variables['prsn'].standard_name == 'snowfall_flux'
-    assert fake_dataset.variables['prsn'].long_name == 'Precipitation as Snow'
+    assert fake_dataset.dependent_varnames() == ["prsn"]
+    assert np.shape(fake_dataset.variables["prsn"]) == (11688, 4, 2)
+    assert fake_dataset.variables["prsn"].standard_name == "snowfall_flux"
+    assert fake_dataset.variables["prsn"].long_name == "Precipitation as Snow"
 
 
-@pytest.mark.parametrize('tiny_dataset, new_var, expected', [
-    ('downscaled_pr', 'prsn', 'prsn_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc'),
-    ('downscaled_pr', 'tasmin', 'tasmin_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc'),
-    ('downscaled_pr', 'tasmax', 'tasmax_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc')
-], indirect=['tiny_dataset'])
+@pytest.mark.parametrize(
+    "tiny_dataset, new_var, expected",
+    [
+        (
+            "downscaled_pr",
+            "prsn",
+            "prsn_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc",
+        ),
+        (
+            "downscaled_pr",
+            "tasmin",
+            "tasmin_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc",
+        ),
+        (
+            "downscaled_pr",
+            "tasmax",
+            "tasmax_day_BCCAQ2_ACCESS1-0_ACCESS1-0+historical+rcp45+r1i1p1_r1i1p1_19600101-19911231.nc",
+        ),
+    ],
+    indirect=["tiny_dataset"],
+)
 def test_create_filepath_from_source(tiny_dataset, new_var, outdir, expected):
-    assert create_filepath_from_source(tiny_dataset, new_var, outdir) == \
-        outdir + '/' + expected
+    assert (
+        create_filepath_from_source(tiny_dataset, new_var, outdir)
+        == outdir + "/" + expected
+    )
 
 
-@pytest.mark.parametrize('required_vars', [
-    (['pr', 'tasmin', 'tasmax']),
-    (['pr', 'tasmin'])
-])
+@pytest.mark.parametrize(
+    "required_vars", [(["pr", "tasmin", "tasmax"]), (["pr", "tasmin"])]
+)
 def test_has_required_vars(required_vars, datasets):
     assert has_required_vars(datasets, required_vars)
 
 
-@pytest.mark.parametrize('required_vars', [
-    (['pr', 'tasmin', 'tasmax', 'missing_var'])
-])
+@pytest.mark.parametrize("required_vars", [(["pr", "tasmin", "tasmax", "missing_var"])])
 def test_has_required_vars_missing_vars(required_vars, datasets):
     assert not has_required_vars(datasets, required_vars)
 
@@ -98,64 +143,62 @@ def test_matching_datasets(datasets):
     assert matching_datasets(datasets)
 
 
-@pytest.mark.parametrize('tiny_dataset', [
-    ('downscaled_pr')
-], indirect=['tiny_dataset'])
+@pytest.mark.parametrize("tiny_dataset", [("downscaled_pr")], indirect=["tiny_dataset"])
 def test_matching_datasets_not_matching(tiny_dataset, datasets):
-    datasets.update({'tiny': tiny_dataset})
+    datasets.update({"tiny": tiny_dataset})
     assert not matching_datasets(datasets)
 
 
-@pytest.mark.parametrize('tiny_dataset', [
-    ('downscaled_pr'),
-    ('downscaled_pr_packed'),
-    ('daily_pr')
-], indirect=['tiny_dataset'])
+@pytest.mark.parametrize(
+    "tiny_dataset",
+    [("downscaled_pr"), ("downscaled_pr_packed"), ("daily_pr")],
+    indirect=["tiny_dataset"],
+)
 def test_check_pr_units(tiny_dataset):
-    assert check_pr_units(tiny_dataset.variables['pr'].units)
+    assert check_pr_units(tiny_dataset.variables["pr"].units)
 
 
-@pytest.mark.parametrize('fake_dataset', [
-    {
-        'dimensions': [('time', 10)],
-        'variables': [
-            {'name': 'pr', 'dimensions': ('time',),
-             'attributes': {'units': 'kg'}},
-        ]
-    }
-], indirect=['fake_dataset'])
+@pytest.mark.parametrize(
+    "fake_dataset",
+    [
+        {
+            "dimensions": [("time", 10)],
+            "variables": [
+                {"name": "pr", "dimensions": ("time",), "attributes": {"units": "kg"}},
+            ],
+        }
+    ],
+    indirect=["fake_dataset"],
+)
 def test_check_pr_units_bad_unit(fake_dataset):
-    assert not check_pr_units(fake_dataset.variables['pr'].units)
+    assert not check_pr_units(fake_dataset.variables["pr"].units)
 
 
-@pytest.mark.parametrize('pr, tasmin, tasmax', [
-    ('daily_pr', 'daily_tasmin', 'daily_tasmax')
-])
-@pytest.mark.parametrize('fake_dataset', [
-    {}
-], indirect=['fake_dataset'])
+@pytest.mark.parametrize(
+    "pr, tasmin, tasmax", [("daily_pr", "daily_tasmin", "daily_tasmax")]
+)
+@pytest.mark.parametrize("fake_dataset", [{}], indirect=["fake_dataset"])
 def test_process_to_prsn(pr, tasmin, tasmax, fake_dataset):
     pr_dataset = get_dataset(pr)
     create_prsn_netcdf_from_source(pr_dataset, fake_dataset)
 
     variables = {
-        'pr': pr_dataset.variables['pr'],
-        'tasmin': get_dataset(tasmin).variables['tasmin'],
-        'tasmax': get_dataset(tasmax).variables['tasmax']
+        "pr": pr_dataset.variables["pr"],
+        "tasmin": get_dataset(tasmin).variables["tasmin"],
+        "tasmax": get_dataset(tasmax).variables["tasmax"],
     }
 
     process_to_prsn(variables, fake_dataset, 1000)
 
-    result = fake_dataset.variables['prsn'][:]
+    result = fake_dataset.variables["prsn"][:]
     result = np.where(result != 0)
     for array in result:
         assert len(array) == 0
 
 
-@pytest.mark.parametrize('units_from, units_to, expected', [
-    ('degC', 'K', 273.15),
-    ('K', 'degC', -273.15)
-])
+@pytest.mark.parametrize(
+    "units_from, units_to, expected", [("degC", "K", 273.15), ("K", "degC", -273.15)]
+)
 def test_convert_temperature_units(units_from, units_to, expected):
     zeros = np.zeros((10, 5))
     result = convert_temperature_units(zeros, units_from, units_to)

--- a/tests/test_split_merged_climos.py
+++ b/tests/test_split_merged_climos.py
@@ -10,61 +10,75 @@ from dp.split_merged_climos import split_merged_climos
 
 # Helper functions
 
+
 def basename_components(filepath):
     """Returns the CMOR(ish) components of the basename (filename) of the given filepath."""
     # Slightly tricky because variable names can contain underscores, which separate components.
     # We find the location f of the frequency component in the split and use it to assemble the components properly.
-    pieces = os.path.basename(filepath).split('_')
-    f = next(i for i, piece in enumerate(pieces) if 'Clim' in piece)
-    return ['_'.join(pieces[:f])] + pieces[f:]
+    pieces = os.path.basename(filepath).split("_")
+    f = next(i for i, piece in enumerate(pieces) if "Clim" in piece)
+    return ["_".join(pieces[:f])] + pieces[f:]
 
 
-datasets = 'gcm_climos gcm_360_climos downscaled_tasmax_climos hydromodel_gcm_climos'.split()
+datasets = (
+    "gcm_climos gcm_360_climos downscaled_tasmax_climos hydromodel_gcm_climos".split()
+)
 
 # Tests
 
-@mark.parametrize('tiny_dataset', datasets, indirect=['tiny_dataset'])
+
+@mark.parametrize("tiny_dataset", datasets, indirect=["tiny_dataset"])
 def test_existence(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
-    expected_num_splits = len(tiny_dataset.frequency[:-4])  # number of letters before 'Clim' is number of interval sets
+    expected_num_splits = len(
+        tiny_dataset.frequency[:-4]
+    )  # number of letters before 'Clim' is number of interval sets
     assert len(split_filepaths) == expected_num_splits
     assert len(os.listdir(outdir)) == expected_num_splits
-    assert set(split_filepaths) == set(os.path.join(outdir, f) for f in os.listdir(outdir))
+    assert set(split_filepaths) == set(
+        os.path.join(outdir, f) for f in os.listdir(outdir)
+    )
 
 
-@mark.parametrize('tiny_dataset', datasets, indirect=['tiny_dataset'])
+@mark.parametrize("tiny_dataset", datasets, indirect=["tiny_dataset"])
 def test_filenames(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
-    assert {basename_components(fp)[0] for fp in split_filepaths} == {'+'.join(sorted(tiny_dataset.dependent_varnames()))}
-    assert {basename_components(fp)[1] for fp in split_filepaths} == {'mClim', 'sClim', 'aClim'}
+    assert {basename_components(fp)[0] for fp in split_filepaths} == {
+        "+".join(sorted(tiny_dataset.dependent_varnames()))
+    }
+    assert {basename_components(fp)[1] for fp in split_filepaths} == {
+        "mClim",
+        "sClim",
+        "aClim",
+    }
 
 
-@mark.parametrize('tiny_dataset', datasets, indirect=['tiny_dataset'])
+@mark.parametrize("tiny_dataset", datasets, indirect=["tiny_dataset"])
 def test_metadata_and_time(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
     for fp in split_filepaths:
         with CFDataset(fp) as cf:
             assert cf.is_multi_year_mean
-            assert cf.frequency in {'mClim', 'sClim', 'aClim'}
+            assert cf.frequency in {"mClim", "sClim", "aClim"}
 
             assert cf.time_var.size == {
-                'mClim': 12,
-                'sClim': 4,
-                'aClim': 1,
+                "mClim": 12,
+                "sClim": 4,
+                "aClim": 1,
             }[cf.frequency]
 
             def d2n(date):
                 return date2num(date, cf.time_var.units, cf.time_var.calendar)
 
-            year = tiny_dataset.time_steps['datetime'][0].year
+            year = tiny_dataset.time_steps["datetime"][0].year
             assert cf.time_var[0] == {
-                'mClim': d2n(datetime(year, 1, 15)),
-                'sClim': d2n(datetime(year, 1, 16)),
-                'aClim': d2n(datetime(year, 7, 2)),
+                "mClim": d2n(datetime(year, 1, 15)),
+                "sClim": d2n(datetime(year, 1, 16)),
+                "aClim": d2n(datetime(year, 7, 2)),
             }[cf.frequency]
 
 
-@mark.parametrize('tiny_dataset', datasets, indirect=['tiny_dataset'])
+@mark.parametrize("tiny_dataset", datasets, indirect=["tiny_dataset"])
 def test_dependent_variables(outdir, tiny_dataset):
     split_filepaths = split_merged_climos(tiny_dataset, outdir)
     for fp in split_filepaths:

--- a/tests/test_units_helpers.py
+++ b/tests/test_units_helpers.py
@@ -4,84 +4,88 @@ from dp.units_helpers import Unit
 
 
 def test_d_for_day():
-    assert Unit('d') == Unit('day')
-    assert Unit('day').to_udunits_str() == 'd'
+    assert Unit("d") == Unit("day")
+    assert Unit("day").to_udunits_str() == "d"
 
 
 udunits_to_pint = [
     # powers on a single unit
-    ('s', 's'),
-    ('s2', 's**2'),
-    ('s^2', 's**2'),
-    ('s**2', 's**2'),
-    ('s-2', 's**-2'),
-    ('s^-2', 's**-2'),
-    ('s**-1', 's**-1'),
-    ('s**-2', 's**-2'),
+    ("s", "s"),
+    ("s2", "s**2"),
+    ("s^2", "s**2"),
+    ("s**2", "s**2"),
+    ("s-2", "s**-2"),
+    ("s^-2", "s**-2"),
+    ("s**-1", "s**-1"),
+    ("s**-2", "s**-2"),
     # multiplication operators
-    ('kg s', 'kg * s'),
-    ('kg  s', 'kg * s'),
-    ('kg-s', 'kg * s'),
-    ('kg- s', 'kg * s'),
-    ('kg -s', 'kg * s'),
-    ('kg - s', 'kg * s'),
-    ('kg.s', 'kg * s'),
-    ('kg. s', 'kg * s'),
-    ('kg .s', 'kg * s'),
-    ('kg . s', 'kg * s'),
-    ('kg m s', 'kg * m * s'),
-    ('kg.m-s', 'kg * m * s'),
+    ("kg s", "kg * s"),
+    ("kg  s", "kg * s"),
+    ("kg-s", "kg * s"),
+    ("kg- s", "kg * s"),
+    ("kg -s", "kg * s"),
+    ("kg - s", "kg * s"),
+    ("kg.s", "kg * s"),
+    ("kg. s", "kg * s"),
+    ("kg .s", "kg * s"),
+    ("kg . s", "kg * s"),
+    ("kg m s", "kg * m * s"),
+    ("kg.m-s", "kg * m * s"),
     # division operator - note spacing is not normalized as with mult
-    ('kg/s', 'kg/s'),
-    ('kg /s', 'kg /s'),
-    ('kg/ s', 'kg/ s'),
-    ('kg / s', 'kg / s'),
+    ("kg/s", "kg/s"),
+    ("kg /s", "kg /s"),
+    ("kg/ s", "kg/ s"),
+    ("kg / s", "kg / s"),
     # combined
-    ('kg m3 / s2', 'kg * m**3 / s**2'),
-    ('kg m**3 / s^2', 'kg * m**3 / s**2'),
-    ('kg m^3 / s**2', 'kg * m**3 / s**2'),
-    ('kg.m^3 / s**2', 'kg * m**3 / s**2'),
-    ('kg m-3 s-2', 'kg * m**-3 * s**-2'),
-    ('kg m^-3 s^-2', 'kg * m**-3 * s**-2'),
-    ('kg m**-3 s**-2', 'kg * m**-3 * s**-2'),
+    ("kg m3 / s2", "kg * m**3 / s**2"),
+    ("kg m**3 / s^2", "kg * m**3 / s**2"),
+    ("kg m^3 / s**2", "kg * m**3 / s**2"),
+    ("kg.m^3 / s**2", "kg * m**3 / s**2"),
+    ("kg m-3 s-2", "kg * m**-3 * s**-2"),
+    ("kg m^-3 s^-2", "kg * m**-3 * s**-2"),
+    ("kg m**-3 s**-2", "kg * m**-3 * s**-2"),
 ]
 
 
-@pytest.mark.parametrize('input, expected', udunits_to_pint)
+@pytest.mark.parametrize("input, expected", udunits_to_pint)
 def test_udunits_str_to_pint_parsable_str(input, expected):
     assert Unit.udunits_str_to_pint_parsable_str(input) == expected
 
 
-@pytest.mark.parametrize('input, expected',
-                         [(udunits_str, Unit(pint_str)) for (udunits_str, pint_str) in udunits_to_pint])
+@pytest.mark.parametrize(
+    "input, expected",
+    [(udunits_str, Unit(pint_str)) for (udunits_str, pint_str) in udunits_to_pint],
+)
 def test_from_udunits(input, expected):
     assert Unit.from_udunits_str(input) == expected
 
 
 pint_to_udunits = [
     # powers on a single unit
-    ('s', 's'),
-    ('s ** 2', 's2'),
-    ('s ** -2', 's-2'),
+    ("s", "s"),
+    ("s ** 2", "s2"),
+    ("s ** -2", "s-2"),
     # multiplication operator
-    ('kg * s', 'kg s'),
-    ('kg * m * s', 'kg m s'),
+    ("kg * s", "kg s"),
+    ("kg * m * s", "kg m s"),
     # division operator
-    ('1 / s', 's-1'),
-    ('1 / s ** 2', 's-2'),
-    ('m / s', 'm s-1'),
-    ('m / s ** 2', 'm s-2'),
+    ("1 / s", "s-1"),
+    ("1 / s ** 2", "s-2"),
+    ("m / s", "m s-1"),
+    ("m / s ** 2", "m s-2"),
     # combined
-    ('kg * m ** 3 / s ** 2', 'kg m3 s-2'),
+    ("kg * m ** 3 / s ** 2", "kg m3 s-2"),
 ]
 
 
-@pytest.mark.parametrize('input, expected', pint_to_udunits)
+@pytest.mark.parametrize("input, expected", pint_to_udunits)
 def test_pint_str_to_udunits_str(input, expected):
     assert Unit.pint_str_to_udunits_str(input) == expected
 
 
-@pytest.mark.parametrize('input, expected',
-                         [(Unit(pint_str), udunits_str) for (pint_str, udunits_str) in pint_to_udunits])
+@pytest.mark.parametrize(
+    "input, expected",
+    [(Unit(pint_str), udunits_str) for (pint_str, udunits_str) in pint_to_udunits],
+)
 def test_to_udunits_str(input, expected):
     assert input.to_udunits_str() == expected

--- a/tests/test_update_metadata.py
+++ b/tests/test_update_metadata.py
@@ -1,20 +1,24 @@
 # TODO: More testing. We're in a hurry. Have tested manually.
 import pytest
 
-from dp.update_metadata import \
-    variable_info, \
-    long_name_for_var, cell_methods_for_var, \
-    normalize_experiment_id, \
-    parse_ensemble_code, \
-    set_attribute_from_expression, \
-    process_updates
+from dp.update_metadata import (
+    variable_info,
+    long_name_for_var,
+    cell_methods_for_var,
+    normalize_experiment_id,
+    parse_ensemble_code,
+    set_attribute_from_expression,
+    process_updates,
+)
 
 
 # Data loading
 
+
 def test_variable_info():
     assert all(
-        key in variable_info for key in '''
+        key in variable_info
+        for key in """
             altcddETCCDI
             altcsdiETCCDI
             altcwdETCCDI
@@ -48,132 +52,163 @@ def test_variable_info():
             txnETCCDI
             txxETCCDI
             wsdiETCCDI
-        '''.split()
+        """.split()
     )
+
 
 # Custom functions
 
-@pytest.mark.parametrize('input_, expected', [
-    ('', ''),
-    ('historical', 'historical'),
-    ('HistorIcaL', 'historical'),
-    ('rcp85', 'rcp85'),
-    ('rcp8.5', 'rcp85'),
-    ('RCP8.5', 'rcp85'),
-    ('Historical, RCP8.5', 'historical, rcp85'),
-    ('one,two ,three,   four  ,  five, six', 'one, two, three, four, five, six'),
-])
+
+@pytest.mark.parametrize(
+    "input_, expected",
+    [
+        ("", ""),
+        ("historical", "historical"),
+        ("HistorIcaL", "historical"),
+        ("rcp85", "rcp85"),
+        ("rcp8.5", "rcp85"),
+        ("RCP8.5", "rcp85"),
+        ("Historical, RCP8.5", "historical, rcp85"),
+        ("one,two ,three,   four  ,  five, six", "one, two, three, four, five, six"),
+    ],
+)
 def test_normalize_experiment_id(input_, expected):
     assert normalize_experiment_id(input_) == expected
 
 
-@pytest.mark.parametrize('input_, expected', [
-    ('r1i2p3', {
-        'realization': 1,
-        'initialization_method': 2,
-        'physics_version': 3,
-    }),
-])
+@pytest.mark.parametrize(
+    "input_, expected",
+    [
+        (
+            "r1i2p3",
+            {
+                "realization": 1,
+                "initialization_method": 2,
+                "physics_version": 3,
+            },
+        ),
+    ],
+)
 def test_parse_ensemble_code(input_, expected):
     assert parse_ensemble_code(input_) == expected
 
 
-@pytest.mark.parametrize('func, arg, result', [
-    (cell_methods_for_var,
-     'tnnETCCDI', 'time: minimum within days time: minimum over months'),
-    (long_name_for_var,
-     'tnnETCCDI', 'Monthly Minimum of Daily Minimum Temperature'),
-])
+@pytest.mark.parametrize(
+    "func, arg, result",
+    [
+        (
+            cell_methods_for_var,
+            "tnnETCCDI",
+            "time: minimum within days time: minimum over months",
+        ),
+        (
+            long_name_for_var,
+            "tnnETCCDI",
+            "Monthly Minimum of Daily Minimum Temperature",
+        ),
+    ],
+)
 def test_variable_info_functions(func, arg, result):
     assert func(arg) == result
 
 
 # Set from expression
 
-@pytest.mark.parametrize('fake_dataset', [
-    {
-        'attributes': {'foo': 'bar'},
-        'dimensions': [('time', 10)],
-        'variables': [
-            {'name': 'var', 'dimensions': ('time',),
-             'attributes': {'baz': 'qux'}},
-        ]
-    }
-], indirect=['fake_dataset'])
+
+@pytest.mark.parametrize(
+    "fake_dataset",
+    [
+        {
+            "attributes": {"foo": "bar"},
+            "dimensions": [("time", 10)],
+            "variables": [
+                {"name": "var", "dimensions": ("time",), "attributes": {"baz": "qux"}},
+            ],
+        }
+    ],
+    indirect=["fake_dataset"],
+)
 class TestSetAttributeFromExpression(object):
-
     def test_fixture(self, fake_dataset):
-        assert fake_dataset.foo == 'bar'
-        assert set(fake_dataset.dimensions.keys()) == {'time'}
-        assert set(fake_dataset.variables.keys()) == {'var'}
-        assert fake_dataset.dependent_varnames() == ['var']
-        assert fake_dataset.variables['var'].baz == 'qux'
+        assert fake_dataset.foo == "bar"
+        assert set(fake_dataset.dimensions.keys()) == {"time"}
+        assert set(fake_dataset.variables.keys()) == {"var"}
+        assert fake_dataset.dependent_varnames() == ["var"]
+        assert fake_dataset.variables["var"].baz == "qux"
 
-    @pytest.mark.parametrize('expression, expected', [
-        ('1+2', 3),
-        ('foo', 'bar'),
-        ('filepath()[-7:]', 'test.nc'),
-        ('str(list(dimensions.keys()))', "['time']"),
-        ('str(list(variables.keys()))', "['var']"),
-        ('str(dependent_varnames())', "['var']"),
-        ('variables[dependent_varnames()[0]].baz', 'qux'),
-        ('dependent_varname', 'var'),
-    ])
+    @pytest.mark.parametrize(
+        "expression, expected",
+        [
+            ("1+2", 3),
+            ("foo", "bar"),
+            ("filepath()[-7:]", "test.nc"),
+            ("str(list(dimensions.keys()))", "['time']"),
+            ("str(list(variables.keys()))", "['var']"),
+            ("str(dependent_varnames())", "['var']"),
+            ("variables[dependent_varnames()[0]].baz", "qux"),
+            ("dependent_varname", "var"),
+        ],
+    )
     def test_context(self, fake_dataset, expression, expected):
         target = fake_dataset
-        set_attribute_from_expression(
-            fake_dataset, target, 'test', expression
-        )
+        set_attribute_from_expression(fake_dataset, target, "test", expression)
         assert target.test == expected
 
 
 # process_updates
 
-@pytest.mark.parametrize('fake_dataset', [
-    {
-        'dimensions': [('time', 10)],
-        'variables': [
-            {'name': 'var1', 'dimensions': ('time',)},
-            {'name': 'var2', 'dimensions': ('time',)},
-        ]
-    }
-], indirect=['fake_dataset'])
-class TestProcessUpdates(object):
 
-    @pytest.mark.parametrize('target_key, target_name', [
-        ('global', 'global'),
-        ('var1', 'var1'),
-        ("='va'+'r1'", 'var1'),
-        ("= dependent_varname", 'var1'),
-    ])
-    def test_process_updates_attributes(self, fake_dataset, target_key, target_name):
-        updates = {
-            target_key: {'yow': '=1+2'}
+@pytest.mark.parametrize(
+    "fake_dataset",
+    [
+        {
+            "dimensions": [("time", 10)],
+            "variables": [
+                {"name": "var1", "dimensions": ("time",)},
+                {"name": "var2", "dimensions": ("time",)},
+            ],
         }
+    ],
+    indirect=["fake_dataset"],
+)
+class TestProcessUpdates(object):
+    @pytest.mark.parametrize(
+        "target_key, target_name",
+        [
+            ("global", "global"),
+            ("var1", "var1"),
+            ("='va'+'r1'", "var1"),
+            ("= dependent_varname", "var1"),
+        ],
+    )
+    def test_process_updates_attributes(self, fake_dataset, target_key, target_name):
+        updates = {target_key: {"yow": "=1+2"}}
         process_updates(fake_dataset, updates)
-        if target_name == 'global':
+        if target_name == "global":
             target = fake_dataset
         else:
             target = fake_dataset.variables[target_name]
         assert target.yow == 3
 
-    @pytest.mark.parametrize('updates, new_name, old_name', [
-        # Failing renames
-        ({'newvar': '<-foovar'}, 'newvar', 'foovar'),  # old not exist
-        ({'var1': '<- var2'}, 'var1', 'var2'),  # new already exists
-        ({'var1': '<- foovar'}, 'var1', 'foovar'), # new exist and old not exist
-
-        # Successful renames - variations on spacing and use of expressions
-        # in both new and old names
-        ({'newvar': '<-var1'}, 'newvar', 'var1'),
-        ({'newvar': '<-     var1'}, 'newvar', 'var1'),
-        ({"='new'+'var'": '<-var1'}, 'newvar', 'var1'),
-        ({'newvar': "<- = 'va'+'r1'"}, 'newvar', 'var1'),
-        ({'newvar': '<- = dependent_varname'}, 'newvar', 'var1'),
-        ({"= 'new'+'var'": '<-= dependent_varname'}, 'newvar', 'var1'),
-    ])
+    @pytest.mark.parametrize(
+        "updates, new_name, old_name",
+        [
+            # Failing renames
+            ({"newvar": "<-foovar"}, "newvar", "foovar"),  # old not exist
+            ({"var1": "<- var2"}, "var1", "var2"),  # new already exists
+            ({"var1": "<- foovar"}, "var1", "foovar"),  # new exist and old not exist
+            # Successful renames - variations on spacing and use of expressions
+            # in both new and old names
+            ({"newvar": "<-var1"}, "newvar", "var1"),
+            ({"newvar": "<-     var1"}, "newvar", "var1"),
+            ({"='new'+'var'": "<-var1"}, "newvar", "var1"),
+            ({"newvar": "<- = 'va'+'r1'"}, "newvar", "var1"),
+            ({"newvar": "<- = dependent_varname"}, "newvar", "var1"),
+            ({"= 'new'+'var'": "<-= dependent_varname"}, "newvar", "var1"),
+        ],
+    )
     def test_process_updates_rename_var(
-            self, fake_dataset, updates, new_name, old_name
+        self, fake_dataset, updates, new_name, old_name
     ):
         old_exists, new_exists = (
             name in fake_dataset.variables for name in (old_name, new_name)


### PR DESCRIPTION
This PR modernizes our installation process and workflows.

Changes:
- replaces `pip` with `pipenv` as installation tool
- bumps OS version to `20.04`
- bumps default python versions to `3.7` and `3.8`
- adds `black` as linting tool

90% of the changes in this PR are from `black`, the only places reviews need to look are:
- `lint.yml`
- `pypi-publish.yml`
- `python-ci.yml`
- `Pipfile` & `Pipfile.lock`
- `README.md`